### PR TITLE
Bug 1215716 - urlencode parameters passed through in the query string

### DIFF
--- a/codegenerator/model/api.go
+++ b/codegenerator/model/api.go
@@ -187,7 +187,8 @@ func (entry *APIEntry) generateAPICode(apiName string) string {
 
 	content := comment
 	content += "    public " + returnType + " " + entry.MethodName + "(" + inputParams + ") throws APICallFailure {\n"
-	content += "        return apiCall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.Replace(strings.Replace(entry.Route, "<", "\" + ", -1), ">", " + \"", -1) + "\", " + responseType + ".class);\n"
+	content += "        return apiCall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.Replace(strings.Replace(entry.Route, "<", "\" + uriEncode(", -1), ">", ") + \"", -1) + "\", " + responseType + ".class);\n"
 	content += "    }\n"
-	return content
+	// can remove any code that added an empty string to another string
+	return strings.Replace(content, ` + ""`, "", -1)
 }

--- a/src/main/java/org/mozilla/taskcluster/client/TaskClusterRequestHandler.java
+++ b/src/main/java/org/mozilla/taskcluster/client/TaskClusterRequestHandler.java
@@ -1,9 +1,11 @@
 package org.mozilla.taskcluster.client;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
@@ -164,5 +166,19 @@ public abstract class TaskClusterRequestHandler {
             throw new APICallFailure(e);
         }
         return callSummary;
+    }
+
+    /**
+     * Utility method to uri encode a parameter for using in url
+     */
+    protected static String uriEncode(String param) {
+        try {
+            return URLEncoder.encode(param, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // This should not be possible since we specify UTF-8
+            e.printStackTrace();
+            System.exit(64);
+        }
+        return null;
     }
 }

--- a/src/main/java/org/mozilla/taskcluster/client/auth/Auth.java
+++ b/src/main/java/org/mozilla/taskcluster/client/auth/Auth.java
@@ -92,7 +92,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#client
      */
     public CallSummary<EmptyPayload, GetClientResponse> client(String clientId) throws APICallFailure {
-        return apiCall(null, "GET", "/clients/" + clientId + "", GetClientResponse.class);
+        return apiCall(null, "GET", "/clients/" + uriEncode(clientId), GetClientResponse.class);
     }
 
     /**
@@ -110,7 +110,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#createClient
      */
     public CallSummary<CreateClientRequest, CreateClientResponse> createClient(String clientId, CreateClientRequest payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/clients/" + clientId + "", CreateClientResponse.class);
+        return apiCall(payload, "PUT", "/clients/" + uriEncode(clientId), CreateClientResponse.class);
     }
 
     /**
@@ -124,7 +124,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#resetAccessToken
      */
     public CallSummary<EmptyPayload, CreateClientResponse> resetAccessToken(String clientId) throws APICallFailure {
-        return apiCall(null, "POST", "/clients/" + clientId + "/reset", CreateClientResponse.class);
+        return apiCall(null, "POST", "/clients/" + uriEncode(clientId) + "/reset", CreateClientResponse.class);
     }
 
     /**
@@ -135,7 +135,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#updateClient
      */
     public CallSummary<CreateClientRequest, GetClientResponse> updateClient(String clientId, CreateClientRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/clients/" + clientId + "", GetClientResponse.class);
+        return apiCall(payload, "POST", "/clients/" + uriEncode(clientId), GetClientResponse.class);
     }
 
     /**
@@ -145,7 +145,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#deleteClient
      */
     public CallSummary<EmptyPayload, EmptyPayload> deleteClient(String clientId) throws APICallFailure {
-        return apiCall(null, "DELETE", "/clients/" + clientId + "", EmptyPayload.class);
+        return apiCall(null, "DELETE", "/clients/" + uriEncode(clientId), EmptyPayload.class);
     }
 
     /**
@@ -165,7 +165,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#role
      */
     public CallSummary<EmptyPayload, GetRoleResponse> role(String roleId) throws APICallFailure {
-        return apiCall(null, "GET", "/roles/" + roleId + "", GetRoleResponse.class);
+        return apiCall(null, "GET", "/roles/" + uriEncode(roleId), GetRoleResponse.class);
     }
 
     /**
@@ -175,7 +175,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#createRole
      */
     public CallSummary<CreateRoleRequest, GetRoleResponse> createRole(String roleId, CreateRoleRequest payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/roles/" + roleId + "", GetRoleResponse.class);
+        return apiCall(payload, "PUT", "/roles/" + uriEncode(roleId), GetRoleResponse.class);
     }
 
     /**
@@ -184,7 +184,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#updateRole
      */
     public CallSummary<CreateRoleRequest, GetRoleResponse> updateRole(String roleId, CreateRoleRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/roles/" + roleId + "", GetRoleResponse.class);
+        return apiCall(payload, "POST", "/roles/" + uriEncode(roleId), GetRoleResponse.class);
     }
 
     /**
@@ -194,7 +194,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#deleteRole
      */
     public CallSummary<EmptyPayload, EmptyPayload> deleteRole(String roleId) throws APICallFailure {
-        return apiCall(null, "DELETE", "/roles/" + roleId + "", EmptyPayload.class);
+        return apiCall(null, "DELETE", "/roles/" + uriEncode(roleId), EmptyPayload.class);
     }
 
     /**
@@ -221,7 +221,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#awsS3Credentials
      */
     public CallSummary<EmptyPayload, AWSS3CredentialsResponse> awsS3Credentials(String level, String bucket, String prefix) throws APICallFailure {
-        return apiCall(null, "GET", "/aws/s3/" + level + "/" + bucket + "/" + prefix + "", AWSS3CredentialsResponse.class);
+        return apiCall(null, "GET", "/aws/s3/" + uriEncode(level) + "/" + uriEncode(bucket) + "/" + uriEncode(prefix), AWSS3CredentialsResponse.class);
     }
 
     /**
@@ -232,7 +232,7 @@ public class Auth extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/auth/api-docs/#azureTableSAS
      */
     public CallSummary<EmptyPayload, AzureSharedAccessSignatureResponse> azureTableSAS(String account, String table) throws APICallFailure {
-        return apiCall(null, "GET", "/azure/" + account + "/table/" + table + "/read-write", AzureSharedAccessSignatureResponse.class);
+        return apiCall(null, "GET", "/azure/" + uriEncode(account) + "/table/" + uriEncode(table) + "/read-write", AzureSharedAccessSignatureResponse.class);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/awsprovisioner/AwsProvisioner.java
+++ b/src/main/java/org/mozilla/taskcluster/client/awsprovisioner/AwsProvisioner.java
@@ -88,7 +88,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#createWorkerType
      */
     public CallSummary<CreateWorkerTypeRequest, GetWorkerTypeRequest> createWorkerType(String workerType, CreateWorkerTypeRequest payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/worker-type/" + workerType + "", GetWorkerTypeRequest.class);
+        return apiCall(payload, "PUT", "/worker-type/" + uriEncode(workerType), GetWorkerTypeRequest.class);
     }
 
     /**
@@ -107,7 +107,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#updateWorkerType
      */
     public CallSummary<CreateWorkerTypeRequest, GetWorkerTypeRequest> updateWorkerType(String workerType, CreateWorkerTypeRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/worker-type/" + workerType + "/update", GetWorkerTypeRequest.class);
+        return apiCall(payload, "POST", "/worker-type/" + uriEncode(workerType) + "/update", GetWorkerTypeRequest.class);
     }
 
     /**
@@ -120,7 +120,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#workerType
      */
     public CallSummary<EmptyPayload, GetWorkerTypeRequest> workerType(String workerType) throws APICallFailure {
-        return apiCall(null, "GET", "/worker-type/" + workerType + "", GetWorkerTypeRequest.class);
+        return apiCall(null, "GET", "/worker-type/" + uriEncode(workerType), GetWorkerTypeRequest.class);
     }
 
     /**
@@ -138,7 +138,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#removeWorkerType
      */
     public CallSummary<EmptyPayload, EmptyPayload> removeWorkerType(String workerType) throws APICallFailure {
-        return apiCall(null, "DELETE", "/worker-type/" + workerType + "", EmptyPayload.class);
+        return apiCall(null, "DELETE", "/worker-type/" + uriEncode(workerType), EmptyPayload.class);
     }
 
     /**
@@ -164,7 +164,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#createSecret
      */
     public CallSummary<GetSecretRequest, EmptyPayload> createSecret(String token, GetSecretRequest payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/secret/" + token + "", EmptyPayload.class);
+        return apiCall(payload, "PUT", "/secret/" + uriEncode(token), EmptyPayload.class);
     }
 
     /**
@@ -179,7 +179,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#getSecret
      */
     public CallSummary<EmptyPayload, GetSecretResponse> getSecret(String token) throws APICallFailure {
-        return apiCall(null, "GET", "/secret/" + token + "", GetSecretResponse.class);
+        return apiCall(null, "GET", "/secret/" + uriEncode(token), GetSecretResponse.class);
     }
 
     /**
@@ -192,7 +192,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#instanceStarted
      */
     public CallSummary<EmptyPayload, EmptyPayload> instanceStarted(String instanceId, String token) throws APICallFailure {
-        return apiCall(null, "GET", "/instance-started/" + instanceId + "/" + token + "", EmptyPayload.class);
+        return apiCall(null, "GET", "/instance-started/" + uriEncode(instanceId) + "/" + uriEncode(token), EmptyPayload.class);
     }
 
     /**
@@ -206,7 +206,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#removeSecret
      */
     public CallSummary<EmptyPayload, EmptyPayload> removeSecret(String token) throws APICallFailure {
-        return apiCall(null, "DELETE", "/secret/" + token + "", EmptyPayload.class);
+        return apiCall(null, "DELETE", "/secret/" + uriEncode(token), EmptyPayload.class);
     }
 
     /**
@@ -219,7 +219,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#getLaunchSpecs
      */
     public CallSummary<EmptyPayload, Object> getLaunchSpecs(String workerType) throws APICallFailure {
-        return apiCall(null, "GET", "/worker-type/" + workerType + "/launch-specifications", Object.class);
+        return apiCall(null, "GET", "/worker-type/" + uriEncode(workerType) + "/launch-specifications", Object.class);
     }
 
     /**
@@ -243,7 +243,7 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/aws-provisioner/api-docs/#state
      */
     public CallSummary<EmptyPayload, EmptyPayload> state(String workerType) throws APICallFailure {
-        return apiCall(null, "GET", "/state/" + workerType + "", EmptyPayload.class);
+        return apiCall(null, "GET", "/state/" + uriEncode(workerType), EmptyPayload.class);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/index/Index.java
+++ b/src/main/java/org/mozilla/taskcluster/client/index/Index.java
@@ -129,7 +129,7 @@ public class Index extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/index/#findTask
      */
     public CallSummary<EmptyPayload, IndexedTaskResponse> findTask(String namespace) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + namespace + "", IndexedTaskResponse.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(namespace), IndexedTaskResponse.class);
     }
 
     /**
@@ -145,7 +145,7 @@ public class Index extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/index/#listNamespaces
      */
     public CallSummary<ListNamespacesRequest, ListNamespacesResponse> listNamespaces(String namespace, ListNamespacesRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/namespaces/" + namespace + "", ListNamespacesResponse.class);
+        return apiCall(payload, "POST", "/namespaces/" + uriEncode(namespace), ListNamespacesResponse.class);
     }
 
     /**
@@ -161,7 +161,7 @@ public class Index extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/index/#listTasks
      */
     public CallSummary<ListTasksRequest, ListTasksResponse> listTasks(String namespace, ListTasksRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/tasks/" + namespace + "", ListTasksResponse.class);
+        return apiCall(payload, "POST", "/tasks/" + uriEncode(namespace), ListTasksResponse.class);
     }
 
     /**
@@ -171,7 +171,7 @@ public class Index extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/index/#insertTask
      */
     public CallSummary<InsertTaskRequest, IndexedTaskResponse> insertTask(String namespace, InsertTaskRequest payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/task/" + namespace + "", IndexedTaskResponse.class);
+        return apiCall(payload, "PUT", "/task/" + uriEncode(namespace), IndexedTaskResponse.class);
     }
 
     /**
@@ -182,7 +182,7 @@ public class Index extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/index/#findArtifactFromTask
      */
     public CallSummary<EmptyPayload, EmptyPayload> findArtifactFromTask(String namespace, String name) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + namespace + "/artifacts/" + name + "", EmptyPayload.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(namespace) + "/artifacts/" + uriEncode(name), EmptyPayload.class);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/purgecache/PurgeCache.java
+++ b/src/main/java/org/mozilla/taskcluster/client/purgecache/PurgeCache.java
@@ -47,7 +47,7 @@ public class PurgeCache extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/purge-cache/#purgeCache
      */
     public CallSummary<PurgeCacheRequest, EmptyPayload> purgeCache(String provisionerId, String workerType, PurgeCacheRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/purge-cache/" + provisionerId + "/" + workerType + "", EmptyPayload.class);
+        return apiCall(payload, "POST", "/purge-cache/" + uriEncode(provisionerId) + "/" + uriEncode(workerType), EmptyPayload.class);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/queue/Queue.java
+++ b/src/main/java/org/mozilla/taskcluster/client/queue/Queue.java
@@ -50,7 +50,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#task
      */
     public CallSummary<EmptyPayload, TaskDefinition1> task(String taskId) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + taskId + "", TaskDefinition1.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(taskId), TaskDefinition1.class);
     }
 
     /**
@@ -59,7 +59,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#status
      */
     public CallSummary<EmptyPayload, TaskStatusResponse> status(String taskId) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + taskId + "/status", TaskStatusResponse.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(taskId) + "/status", TaskStatusResponse.class);
     }
 
     /**
@@ -85,7 +85,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#createTask
      */
     public CallSummary<TaskDefinition, TaskStatusResponse> createTask(String taskId, TaskDefinition payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/task/" + taskId + "", TaskStatusResponse.class);
+        return apiCall(payload, "PUT", "/task/" + uriEncode(taskId), TaskStatusResponse.class);
     }
 
     /**
@@ -107,7 +107,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#defineTask
      */
     public CallSummary<TaskDefinition, TaskStatusResponse> defineTask(String taskId, TaskDefinition payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/task/" + taskId + "/define", TaskStatusResponse.class);
+        return apiCall(payload, "POST", "/task/" + uriEncode(taskId) + "/define", TaskStatusResponse.class);
     }
 
     /**
@@ -123,7 +123,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#scheduleTask
      */
     public CallSummary<EmptyPayload, TaskStatusResponse> scheduleTask(String taskId) throws APICallFailure {
-        return apiCall(null, "POST", "/task/" + taskId + "/schedule", TaskStatusResponse.class);
+        return apiCall(null, "POST", "/task/" + uriEncode(taskId) + "/schedule", TaskStatusResponse.class);
     }
 
     /**
@@ -143,7 +143,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#rerunTask
      */
     public CallSummary<EmptyPayload, TaskStatusResponse> rerunTask(String taskId) throws APICallFailure {
-        return apiCall(null, "POST", "/task/" + taskId + "/rerun", TaskStatusResponse.class);
+        return apiCall(null, "POST", "/task/" + uriEncode(taskId) + "/rerun", TaskStatusResponse.class);
     }
 
     /**
@@ -163,7 +163,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#cancelTask
      */
     public CallSummary<EmptyPayload, TaskStatusResponse> cancelTask(String taskId) throws APICallFailure {
-        return apiCall(null, "POST", "/task/" + taskId + "/cancel", TaskStatusResponse.class);
+        return apiCall(null, "POST", "/task/" + uriEncode(taskId) + "/cancel", TaskStatusResponse.class);
     }
 
     /**
@@ -174,7 +174,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#pollTaskUrls
      */
     public CallSummary<EmptyPayload, PollTaskUrlsResponse> pollTaskUrls(String provisionerId, String workerType) throws APICallFailure {
-        return apiCall(null, "GET", "/poll-task-url/" + provisionerId + "/" + workerType + "", PollTaskUrlsResponse.class);
+        return apiCall(null, "GET", "/poll-task-url/" + uriEncode(provisionerId) + "/" + uriEncode(workerType), PollTaskUrlsResponse.class);
     }
 
     /**
@@ -183,7 +183,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#claimTask
      */
     public CallSummary<TaskClaimRequest, TaskClaimResponse> claimTask(String taskId, String runId, TaskClaimRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/task/" + taskId + "/runs/" + runId + "/claim", TaskClaimResponse.class);
+        return apiCall(payload, "POST", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/claim", TaskClaimResponse.class);
     }
 
     /**
@@ -192,7 +192,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#reclaimTask
      */
     public CallSummary<EmptyPayload, TaskClaimResponse> reclaimTask(String taskId, String runId) throws APICallFailure {
-        return apiCall(null, "POST", "/task/" + taskId + "/runs/" + runId + "/reclaim", TaskClaimResponse.class);
+        return apiCall(null, "POST", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/reclaim", TaskClaimResponse.class);
     }
 
     /**
@@ -201,7 +201,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#reportCompleted
      */
     public CallSummary<EmptyPayload, TaskStatusResponse> reportCompleted(String taskId, String runId) throws APICallFailure {
-        return apiCall(null, "POST", "/task/" + taskId + "/runs/" + runId + "/completed", TaskStatusResponse.class);
+        return apiCall(null, "POST", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/completed", TaskStatusResponse.class);
     }
 
     /**
@@ -216,7 +216,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#reportFailed
      */
     public CallSummary<EmptyPayload, TaskStatusResponse> reportFailed(String taskId, String runId) throws APICallFailure {
-        return apiCall(null, "POST", "/task/" + taskId + "/runs/" + runId + "/failed", TaskStatusResponse.class);
+        return apiCall(null, "POST", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/failed", TaskStatusResponse.class);
     }
 
     /**
@@ -236,7 +236,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#reportException
      */
     public CallSummary<TaskExceptionRequest, TaskStatusResponse> reportException(String taskId, String runId, TaskExceptionRequest payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/task/" + taskId + "/runs/" + runId + "/exception", TaskStatusResponse.class);
+        return apiCall(payload, "POST", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/exception", TaskStatusResponse.class);
     }
 
     /**
@@ -302,7 +302,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#createArtifact
      */
     public CallSummary<Object, Object> createArtifact(String taskId, String runId, String name, Object payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/task/" + taskId + "/runs/" + runId + "/artifacts/" + name + "", Object.class);
+        return apiCall(payload, "POST", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/artifacts/" + uriEncode(name), Object.class);
     }
 
     /**
@@ -321,7 +321,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#getArtifact
      */
     public CallSummary<EmptyPayload, EmptyPayload> getArtifact(String taskId, String runId, String name) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + taskId + "/runs/" + runId + "/artifacts/" + name + "", EmptyPayload.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/artifacts/" + uriEncode(name), EmptyPayload.class);
     }
 
     /**
@@ -344,7 +344,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#getLatestArtifact
      */
     public CallSummary<EmptyPayload, EmptyPayload> getLatestArtifact(String taskId, String name) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + taskId + "/artifacts/" + name + "", EmptyPayload.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(taskId) + "/artifacts/" + uriEncode(name), EmptyPayload.class);
     }
 
     /**
@@ -353,7 +353,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#listArtifacts
      */
     public CallSummary<EmptyPayload, ListArtifactsResponse> listArtifacts(String taskId, String runId) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + taskId + "/runs/" + runId + "/artifacts", ListArtifactsResponse.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(taskId) + "/runs/" + uriEncode(runId) + "/artifacts", ListArtifactsResponse.class);
     }
 
     /**
@@ -363,7 +363,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#listLatestArtifacts
      */
     public CallSummary<EmptyPayload, ListArtifactsResponse> listLatestArtifacts(String taskId) throws APICallFailure {
-        return apiCall(null, "GET", "/task/" + taskId + "/artifacts", ListArtifactsResponse.class);
+        return apiCall(null, "GET", "/task/" + uriEncode(taskId) + "/artifacts", ListArtifactsResponse.class);
     }
 
     /**
@@ -374,7 +374,7 @@ public class Queue extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/queue/api-docs/#pendingTasks
      */
     public CallSummary<EmptyPayload, CountPendingTasksResponse> pendingTasks(String provisionerId, String workerType) throws APICallFailure {
-        return apiCall(null, "GET", "/pending/" + provisionerId + "/" + workerType + "", CountPendingTasksResponse.class);
+        return apiCall(null, "GET", "/pending/" + uriEncode(provisionerId) + "/" + uriEncode(workerType), CountPendingTasksResponse.class);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/scheduler/Scheduler.java
+++ b/src/main/java/org/mozilla/taskcluster/client/scheduler/Scheduler.java
@@ -110,7 +110,7 @@ public class Scheduler extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/scheduler/api-docs/#createTaskGraph
      */
     public CallSummary<TaskGraphDefinition1, TaskGraphStatusResponse> createTaskGraph(String taskGraphId, TaskGraphDefinition1 payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/task-graph/" + taskGraphId + "", TaskGraphStatusResponse.class);
+        return apiCall(payload, "PUT", "/task-graph/" + uriEncode(taskGraphId), TaskGraphStatusResponse.class);
     }
 
     /**
@@ -131,7 +131,7 @@ public class Scheduler extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/scheduler/api-docs/#extendTaskGraph
      */
     public CallSummary<TaskGraphDefinition, TaskGraphStatusResponse> extendTaskGraph(String taskGraphId, TaskGraphDefinition payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/task-graph/" + taskGraphId + "/extend", TaskGraphStatusResponse.class);
+        return apiCall(payload, "POST", "/task-graph/" + uriEncode(taskGraphId) + "/extend", TaskGraphStatusResponse.class);
     }
 
     /**
@@ -144,7 +144,7 @@ public class Scheduler extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/scheduler/api-docs/#status
      */
     public CallSummary<EmptyPayload, TaskGraphStatusResponse> status(String taskGraphId) throws APICallFailure {
-        return apiCall(null, "GET", "/task-graph/" + taskGraphId + "/status", TaskGraphStatusResponse.class);
+        return apiCall(null, "GET", "/task-graph/" + uriEncode(taskGraphId) + "/status", TaskGraphStatusResponse.class);
     }
 
     /**
@@ -158,7 +158,7 @@ public class Scheduler extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/scheduler/api-docs/#info
      */
     public CallSummary<EmptyPayload, TaskGraphInfoResponse> info(String taskGraphId) throws APICallFailure {
-        return apiCall(null, "GET", "/task-graph/" + taskGraphId + "/info", TaskGraphInfoResponse.class);
+        return apiCall(null, "GET", "/task-graph/" + uriEncode(taskGraphId) + "/info", TaskGraphInfoResponse.class);
     }
 
     /**
@@ -178,7 +178,7 @@ public class Scheduler extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/scheduler/api-docs/#inspect
      */
     public CallSummary<EmptyPayload, InspectTaskGraphResponse> inspect(String taskGraphId) throws APICallFailure {
-        return apiCall(null, "GET", "/task-graph/" + taskGraphId + "/inspect", InspectTaskGraphResponse.class);
+        return apiCall(null, "GET", "/task-graph/" + uriEncode(taskGraphId) + "/inspect", InspectTaskGraphResponse.class);
     }
 
     /**
@@ -198,7 +198,7 @@ public class Scheduler extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/scheduler/api-docs/#inspectTask
      */
     public CallSummary<EmptyPayload, InspectTaskGraphTaskResponse> inspectTask(String taskGraphId, String taskId) throws APICallFailure {
-        return apiCall(null, "GET", "/task-graph/" + taskGraphId + "/inspect/" + taskId + "", InspectTaskGraphTaskResponse.class);
+        return apiCall(null, "GET", "/task-graph/" + uriEncode(taskGraphId) + "/inspect/" + uriEncode(taskId), InspectTaskGraphTaskResponse.class);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/secrets/Secrets.java
+++ b/src/main/java/org/mozilla/taskcluster/client/secrets/Secrets.java
@@ -42,7 +42,7 @@ public class Secrets extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/secrets/#set
      */
     public CallSummary<ATaskClusterSecret, EmptyPayload> set(String name, ATaskClusterSecret payload) throws APICallFailure {
-        return apiCall(payload, "PUT", "/secrets/" + name + "", EmptyPayload.class);
+        return apiCall(payload, "PUT", "/secrets/" + uriEncode(name), EmptyPayload.class);
     }
 
     /**
@@ -51,7 +51,7 @@ public class Secrets extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/secrets/#update
      */
     public CallSummary<ATaskClusterSecret, EmptyPayload> update(String name, ATaskClusterSecret payload) throws APICallFailure {
-        return apiCall(payload, "POST", "/secrets/" + name + "", EmptyPayload.class);
+        return apiCall(payload, "POST", "/secrets/" + uriEncode(name), EmptyPayload.class);
     }
 
     /**
@@ -60,7 +60,7 @@ public class Secrets extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/secrets/#remove
      */
     public CallSummary<EmptyPayload, EmptyPayload> remove(String name) throws APICallFailure {
-        return apiCall(null, "DELETE", "/secrets/" + name + "", EmptyPayload.class);
+        return apiCall(null, "DELETE", "/secrets/" + uriEncode(name), EmptyPayload.class);
     }
 
     /**
@@ -69,7 +69,7 @@ public class Secrets extends TaskClusterRequestHandler {
      * See http://docs.taskcluster.net/services/secrets/#get
      */
     public CallSummary<EmptyPayload, ATaskClusterSecret> get(String name) throws APICallFailure {
-        return apiCall(null, "GET", "/secrets/" + name + "", ATaskClusterSecret.class);
+        return apiCall(null, "GET", "/secrets/" + uriEncode(name), ATaskClusterSecret.class);
     }
 
     /**


### PR DESCRIPTION
Only changed `codegenerator/model/api.go` and  `src/main/java/org/mozilla/taskcluster/client/TaskClusterRequestHandler.java` - the other files get generated.

Therefore please review only the changes to these two files and check that the generated files look sane. Luckily these two files should be the first two files shown in the "Files changed" tab. :) Thanks!