### PR TITLE
Creds cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ A java port of taskcluster-client.
 
 Currently AMQP APIs are not supported in the java client.
 
+### Client utilities
+
+* [Credentials](http://taskcluster.github.io/taskcluster-client-java/apidocs/org/mozilla/taskcluster/client/Credentials.html)  
+  For credentials operations, such as:
+    * Creating temporary credentials from permanent credentials
+    * Limiting credentials to a set of authorized scopes
+
 ## Using
 
 ### Maven
@@ -67,8 +74,9 @@ The taskcluster-client artifacts are now available from the [maven central repos
 
 ## Calling API End-Points
 
-To invoke an API end-point, instantiate one of the HTTP API classes (from section [HTTP APIs](#http-apis)).
-In the following example we instantiate an instance of the `Queue` client class and use it to create a task.
+To invoke an API end-point, instantiate one of the HTTP API classes (from
+section [HTTP APIs](#http-apis)).  In the following example we instantiate an
+instance of the `Queue` client class and use it to create a task.
 
 ```java
 import org.mozilla.taskcluster.client.*;
@@ -76,11 +84,15 @@ import org.mozilla.taskcluster.client.queue.*;
 
 ...
 
-    // Instantiate the Queue Client class
-    Queue queue = new Queue(System.getenv("TASKCLUSTER_CLIENT_ID"), System.getenv("TASKCLUSTER_ACCESS_TOKEN"));
+	// Create credentials, e.g. from environment variables...
+    Credentials creds = new Credentials(
+        System.getenv("TASKCLUSTER_CLIENT_ID"),
+        System.getenv("TASKCLUSTER_ACCESS_TOKEN"),
+        System.getenv("TASKCLUSTER_CERTIFICATE")
+    );
 
-    // Certificate must also be provided if using temporary credentials
-    // Queue queue = new Queue(System.getenv("TASKCLUSTER_CLIENT_ID"), System.getenv("TASKCLUSTER_ACCESS_TOKEN"), System.getenv("TASKCLUSTER_CERTIFICATE"));
+    // Instantiate the Queue client class
+    Queue queue = new Queue(creds);
 
     // Supply a unique task name
     String taskId = "...";
@@ -108,46 +120,93 @@ import org.mozilla.taskcluster.client.queue.*;
 ...
 ```
 ## Temporary credentials
+
+You can generate temporary credentials from permanent credentials using the
+java client. This may be useful if you wish to issue credentials to a third
+party. See http://docs.taskcluster.net/auth/temporary-credentials/ for more
+information. Both named and unnamed temporary credentials are supported,
+although named credentials are preferred if you are not sure which type to use.
+
+### Example
+
 ```java
+package org.mozilla.taskcluster;
+
+import java.util.Date;
+
+import org.mozilla.taskcluster.client.APICallFailure;
+import org.mozilla.taskcluster.client.CallSummary;
 import org.mozilla.taskcluster.client.Credentials;
+import org.mozilla.taskcluster.client.EmptyPayload;
+import org.mozilla.taskcluster.client.InvalidOptionsException;
+import org.mozilla.taskcluster.client.queue.ListArtifactsResponse;
+import org.mozilla.taskcluster.client.queue.ListArtifactsResponse.Artifacts;
+import org.mozilla.taskcluster.client.queue.Queue;
 
-...
-  //The client's access token
-  String accessToken = "...";
-
-  //client id  
-  String clientId = "...";
-
-  String[] scopes = {...};
-
-  // The credentials are valid for a maximum of 31 days only
-  Date start = new Date(...);
-  Date expiry = new Date(...);
-
-  //Unnamed Credentials
-  Credentials credentials = Credentials.createTemporaryCredentials(
-    clientId , accessToken , scopes , start , expiry
-  );
-
-...
-  //named credentials
-  String issuer = "...";
-
-  credentials = Credentials.createTemporaryCredentials(
-    clientId, issuer, accessToken , scopes , start , expiry
-  );
+/**
+ * This simple demo lists the artifacts in run 0 of task U7On2dUVS9KlEgw7LUaCMQ.
+ * It creates permanent credentials from environment variables
+ * TASKCLUSTER_CLIENT_ID and TASKCLUSTER_ACCESS_TOKEN, and then creates
+ * temporary credentials, valid for 24 hours, from these permanent credentials.
+ * It queries the Queue using the temporary credentials, and with limited
+ * authorized scopes.
+ *
+ * Note, the queue.listArtifacts(...) call doesn't require any scopes, the
+ * generation of temporary credentials, and limiting via authorized scopes is
+ * purely illustrative.
+ */
+public class Demo {
+    public static void main(String[] args) {
+        Credentials permCreds = new Credentials(
+            System.getenv("TASKCLUSTER_CLIENT_ID"),
+            System.getenv("TASKCLUSTER_ACCESS_TOKEN"),
+            null
+        );
+        Date now = new Date();
+        try {
+            Credentials tempCreds = permCreds.createTemporaryCredentials(
+                "demo-client/taskcluster-client-java",
+                new String[] {
+                    "assume:legacy-permacred"
+                },
+                // valid immediately
+                now,
+                // expire in 24 hours
+                new Date(now.getTime() + 1000 * 60 * 60 * 24)
+            );
+            tempCreds.authorizedScopes = new String[] { "queue:get-artifact:private/build/*" };
+            Queue queue = new Queue(tempCreds);
+            CallSummary<EmptyPayload, ListArtifactsResponse> cs = queue.listArtifacts("U7On2dUVS9KlEgw7LUaCMQ", "0");
+            ListArtifactsResponse artifacts = cs.responsePayload;
+            System.out.println("Artifacts:");
+            for (Artifacts artifact : artifacts.artifacts) {
+                System.out.println("  * " + artifact.name);
+            }
+            System.out.println("Done.");
+        } catch (InvalidOptionsException e) {
+            System.err.println("Could not create temporary credentials");
+            e.printStackTrace();
+        } catch (APICallFailure e) {
+            System.err.println("Could not query the Queue service");
+            e.printStackTrace();
+        }
+    }
+}
 ```
 
-See the [HTTP API javadocs](#http-apis) for more information, or browse the [unit tests](https://github.com/taskcluster/taskcluster-client-java/tree/master/src/test/java/org/mozilla/taskcluster) for further examples.
+See the [HTTP API javadocs](#http-apis) for more information, or browse the [unit
+tests](https://github.com/taskcluster/taskcluster-client-java/tree/master/src/test/java/org/mozilla/taskcluster)
+for further examples.
+
 ## Building
 
-[![GoDoc](https://godoc.org/github.com/taskcluster/taskcluster-client-java?status.svg)](https://godoc.org/github.com/taskcluster/taskcluster-client-java)
-
 The java libraries provided by this client are auto-generated in
-[go](https://golang.org/) using the schemas defined in
+[go](https://golang.org/) (not java!) using the schemas defined in
 http://references.taskcluster.net/manifest.json combined with supplementary
 information stored in
 [apis.json](https://github.com/taskcluster/taskcluster-client-java/blob/master/codegenerator/model/apis.json).
+
+[![GoDoc](https://godoc.org/github.com/taskcluster/taskcluster-client-java?status.svg)](https://godoc.org/github.com/taskcluster/taskcluster-client-java)
 
 In order to completely regenerate all of the HTTP and AMQP libraries, please run
 [build.sh](https://github.com/taskcluster/taskcluster-client-java/blob/master/build.sh)
@@ -163,4 +222,5 @@ directory.
 
 ## Contributing
 
-Contributions are welcome. Please fork, and issue a Pull Request back with an explanation of your changes.
+Contributions are welcome. Please fork, and issue a Pull Request back with an
+explanation of your changes.

--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ import org.mozilla.taskcluster.client.queue.Queue;
  *
  * Note, the queue.listArtifacts(...) call doesn't require any scopes, the
  * generation of temporary credentials, and limiting via authorized scopes is
- * purely illustrative.
+ * purely illustrative. The TASKCLUSTER_CLIENT_ID must satisfy
+ * auth:create-client:demo-client/taskcluster-client-java, though.
  */
 public class Demo {
     public static void main(String[] args) {
         Credentials permCreds = new Credentials(
             System.getenv("TASKCLUSTER_CLIENT_ID"),
-            System.getenv("TASKCLUSTER_ACCESS_TOKEN"),
-            null
+            System.getenv("TASKCLUSTER_ACCESS_TOKEN")
         );
         Date now = new Date();
         try {

--- a/codegenerator/model/api.go
+++ b/codegenerator/model/api.go
@@ -55,6 +55,7 @@ func (api *API) generateAPICode(apiName string) string {
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -74,20 +75,12 @@ import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
     protected static final String defaultBaseURL = "` + api.BaseURL + `";
 
-    public ` + className + `(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public ` + className + `(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public ` + className + `(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public ` + className + `(String baseURL) {
-        super(baseURL);
-    }
-
-    public ` + className + `() {
-        super(defaultBaseURL);
+    public ` + className + `(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 `
 	for _, entry := range api.Entries {

--- a/codegenerator/model/api.go
+++ b/codegenerator/model/api.go
@@ -82,6 +82,22 @@ import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
     public ` + className + `(Credentials credentials, String baseURL) {
         super(credentials, baseURL);
     }
+
+    public ` + className + `(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public ` + className + `(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public ` + className + `(String baseURL) {
+        super(baseURL);
+    }
+
+    public ` + className + `() {
+        super(defaultBaseURL);
+    }
 `
 	for _, entry := range api.Entries {
 		content += entry.generateAPICode(apiName)

--- a/pom.xml
+++ b/pom.xml
@@ -118,21 +118,32 @@
 			</plugin>
 			<plugin>
 				<!-- so we can publish to coveralls.io from travis-ci.org -->
-			    <groupId>org.eluder.coveralls</groupId>
-			    <artifactId>coveralls-maven-plugin</artifactId>
-			    <version>3.1.0</version>
+				<groupId>org.eluder.coveralls</groupId>
+				<artifactId>coveralls-maven-plugin</artifactId>
+				<version>3.1.0</version>
 			</plugin>
 			<plugin>
 				<!-- so we can generate code coverage reports -->
-			    <groupId>org.codehaus.mojo</groupId>
-			    <artifactId>cobertura-maven-plugin</artifactId>
-			    <version>2.6</version>
-			    <configuration>
-			        <format>xml</format>
-			        <maxmem>256m</maxmem>
-			        <!-- aggregated reports for multi-module projects -->
-			        <aggregate>true</aggregate>
-			    </configuration>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<format>xml</format>
+					<maxmem>256m</maxmem>
+					<!-- aggregated reports for multi-module projects -->
+					<aggregate>true</aggregate>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemProperties>
+						<property>
+							<name>java.util.logging.config.file</name>
+							<value>src/test/resources/logging.properties</value>
+						</property>
+					</systemProperties>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/org/mozilla/taskcluster/client/Certificate.java
+++ b/src/main/java/org/mozilla/taskcluster/client/Certificate.java
@@ -1,124 +1,93 @@
 package org.mozilla.taskcluster.client;
 
 import java.nio.ByteBuffer;
-
 import java.util.Date;
 import java.util.UUID;
-import java.security.NoSuchAlgorithmException;
-import java.security.InvalidKeyException;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.UnsupportedEncodingException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import net.iharder.Base64;
 
-import com.google.gson.Gson;
-
-/*
-  This class handles creation of cretificates and generation of signatures.
-  Output is provided as JSON string.
-
-  constructors:
-    Default
-    Certificate(int version, Date start, Date expiry, String scopes[])
-    Certificate(int version, Date start, Date expiry, String scopes[], String clientId, String issuer)
-
-  public methods:
-  generateSignature(String)
-    This generates the signature based on the access token
-*/
+/**
+ * TaskCluster certificates are used in temporary credentials when
+ * authenticating against TaskCluster HTTP(S) end points.
+ */
 
 public class Certificate {
 
-  public int version = 1;
-  public String[] scopes;
-  public long start;
-  public long expiry;
-  public String seed;
-  public String signature = null;
-  private final transient String algo = "HmacSHA256";
-  //For named credentials
-  public String issuer = null;
-  public String clientId = null;
+    public int                     version   = 1;
+    public String[]                scopes;
+    public long                    start;
+    public long                    expiry;
+    public String                  seed;
+    public String                  signature = null;
+    private final transient String algo      = "HmacSHA256";
+    // For named credentials
+    public String                  issuer    = null;
 
-  public Certificate(int version, Date start, Date expiry, String scopes[]){
-    this.version = version;
-    this.start = start.getTime();
-    this.expiry = expiry.getTime();
-    this.scopes = scopes;
-    issuer = null;
-    signature = null;
-    generateSeed();
-  }
-
-  public Certificate(int version, Date start, Date expiry,
-  String scopes[], String clientId, String issuer){
-    this.version = version;
-    this.start = start.getTime();
-    this.expiry = expiry.getTime();
-    this.scopes = scopes;
-    this.issuer = issuer;
-    this.clientId = clientId;
-    signature = null;
-    generateSeed();
-  }
-
-  private void generateSeed(){
-    seed = slug()+slug();
-  }
-
-  public static String slug() {
-      UUID uuid = UUID.randomUUID();
-      long hi = uuid.getMostSignificantBits();
-      long lo = uuid.getLeastSignificantBits();
-      ByteBuffer raw = ByteBuffer.allocate(16);
-      raw.putLong(hi);
-      raw.putLong(lo);
-      byte[] rawBytes = raw.array();
-      return Base64.encodeBytes(rawBytes).replace('+', '-').replace('/', '_').substring(0, 22);
-  }
-
-  public void generateSignature(String accessToken)
-  throws InvalidOptionsException{
-    try{
-      SecretKeySpec keySpec = new SecretKeySpec(accessToken.getBytes("utf-8"),algo);
-      Mac mac = Mac.getInstance(algo);
-      mac.init(keySpec);
-
-      StringBuilder builder = new StringBuilder();
-
-      //Accumulator like stuff
-      builder.append("version:" + Integer.toString(version) + "\n");
-      //for named credentials
-      if(clientId != null && issuer != null){
-        builder.append("clientId:"+clientId+"\n");
-        builder.append("issuer:"+issuer+"\n");
-      }
-      builder.append("seed:"+seed+"\n");
-      builder.append("start:"+Long.toString(start)+"\n");
-      builder.append("expiry:"+Long.toString(expiry)+"\n");
-      builder.append("scopes:\n");
-      //Appending scopes
-      String prefix = "";
-      for(String scope : scopes){
-        builder.append(prefix);
-        prefix = "\n";
-        builder.append(scope);
-      }
-      String temp = builder.toString();
-
-      //Set the signature as base64 encoded string
-      this.signature = Base64.encodeBytes(mac.doFinal(temp.getBytes("utf-8")));
-
-    }catch(Exception e){
-      e.printStackTrace();
-      throw new InvalidOptionsException(e);
+    public Certificate(int version, Date start, Date expiry, String scopes[]) {
+        this.version = version;
+        this.start = start.getTime();
+        this.expiry = expiry.getTime();
+        this.scopes = scopes;
+        signature = null;
+        generateSeed();
     }
-  }
 
-  public String toString(){
-    Gson gson = new Gson();
-    return gson.toJson(this);
-  }
+    private void generateSeed() {
+        seed = slug() + slug();
+    }
+
+    private static String slug() {
+        UUID uuid = UUID.randomUUID();
+        long hi = uuid.getMostSignificantBits();
+        long lo = uuid.getLeastSignificantBits();
+        ByteBuffer raw = ByteBuffer.allocate(16);
+        raw.putLong(hi);
+        raw.putLong(lo);
+        byte[] rawBytes = raw.array();
+        return Base64.encodeBytes(rawBytes).replace('+', '-').replace('/', '_').substring(0, 22);
+    }
+
+    public void generateSignature(String accessToken, String tempClientId) throws InvalidOptionsException {
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(accessToken.getBytes("utf-8"), algo);
+            Mac mac = Mac.getInstance(algo);
+            mac.init(keySpec);
+
+            StringBuilder builder = new StringBuilder();
+
+            // Accumulator like stuff
+            builder.append("version:" + Integer.toString(version) + "\n");
+            // for named credentials
+            if (tempClientId != null && issuer != null && !tempClientId.equals("") && !issuer.equals("")) {
+                builder.append("clientId:" + tempClientId + "\n");
+                builder.append("issuer:" + issuer + "\n");
+            }
+            builder.append("seed:" + seed + "\n");
+            builder.append("start:" + Long.toString(start) + "\n");
+            builder.append("expiry:" + Long.toString(expiry) + "\n");
+            builder.append("scopes:");
+            for (String scope : scopes) {
+                builder.append("\n" + scope);
+            }
+            String temp = builder.toString();
+
+            // Set the signature as base64 encoded string
+            this.signature = Base64.encodeBytes(mac.doFinal(temp.getBytes("utf-8")));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new InvalidOptionsException(e);
+        }
+    }
+
+    public String toString() {
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+        return gson.toJson(this);
+    }
 }

--- a/src/main/java/org/mozilla/taskcluster/client/Certificate.java
+++ b/src/main/java/org/mozilla/taskcluster/client/Certificate.java
@@ -43,6 +43,7 @@ public class Certificate {
     }
 
     private static String slug() {
+        // The UUID is generated using a cryptographically strong pseudo random number generator
         UUID uuid = UUID.randomUUID();
         long hi = uuid.getMostSignificantBits();
         long lo = uuid.getLeastSignificantBits();

--- a/src/main/java/org/mozilla/taskcluster/client/Credentials.java
+++ b/src/main/java/org/mozilla/taskcluster/client/Credentials.java
@@ -32,6 +32,13 @@ public class Credentials {
     private Credentials() {
     }
 
+    public Credentials(String clientId, String accessToken) {
+        this.clientId = clientId;
+        this.accessToken = accessToken;
+        this.certificate = null;
+        configureHawk();
+    }
+
     public Credentials(String clientId, String accessToken, String certificate) {
         this.clientId = clientId;
         this.accessToken = accessToken;

--- a/src/main/java/org/mozilla/taskcluster/client/Credentials.java
+++ b/src/main/java/org/mozilla/taskcluster/client/Credentials.java
@@ -1,92 +1,126 @@
 package org.mozilla.taskcluster.client;
 
+import java.net.URI;
 import java.util.Date;
-import java.security.NoSuchAlgorithmException;
-import java.security.InvalidKeyException;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.UnsupportedEncodingException;
 
 import com.google.gson.Gson;
+import com.wealdtech.hawk.HawkClient;
+import com.wealdtech.hawk.HawkCredentials;
+import com.wealdtech.hawk.HawkCredentials.Algorithm;
 
 import net.iharder.Base64;
 
-import org.mozilla.taskcluster.client.InvalidOptionsException;
-
 public class Credentials {
-  public final static transient String algo = "HmacSHA256";
-  public String accessToken = "";
-  public String clientId = null;
-  public Certificate certificate = null;
+    private transient final static String algo             = "HmacSHA256";
+    public String[]                       authorizedScopes = null;
+    public String                         accessToken      = "";
+    public String                         clientId         = null;
+    public String                         certificate      = null;
+    private transient HawkClient          hawkClient;
 
-  //Let this just...be there
-  private Credentials(){
-    accessToken = null;
-    clientId = null;
-    certificate = null;
-  }
-
-  public Credentials(String accessToken, String clientId, Certificate certificate){
-    this.accessToken = accessToken;
-    this.clientId = clientId;
-    this.certificate = certificate;
-  }
-
-  /*
-    This method is used to generate unnamed temporary
-    credentials
-  */
-  public static Credentials createTemporaryCredentials(String clientId, String accessToken,
-  String[] scopes, Date start, Date expiry) throws InvalidOptionsException {
-    //Check dates
-    if(start.after(expiry)){
-      //throw error
-      throw new InvalidOptionsException(new Throwable("start should be before expiry"));
+    public void configureHawk() {
+        HawkCredentials hawkCredentials = new HawkCredentials.Builder().keyId(clientId).key(accessToken)
+                .algorithm(Algorithm.SHA256).build();
+        hawkClient = new HawkClient.Builder().credentials(hawkCredentials).build();
     }
-    if((long)(expiry.getTime() - start.getTime()) > (long) 31*24*60*60*1000){
-      //throw error
-      throw new InvalidOptionsException(new Throwable("Cannot exceed 31 days"));
-    }
-    Certificate cert = new Certificate(1,start,expiry,scopes);
-    //Create signature;
-    cert.generateSignature(accessToken);
-    String temporaryAccessToken = generateTemporaryAccessToken(accessToken, cert.seed);
-    return new Credentials(temporaryAccessToken, clientId, cert);
-  }
 
-  public static Credentials createTemporaryCredentials(String clientId, String issuer,
-  String accessToken, String[] scopes, Date start, Date expiry)
-  throws InvalidOptionsException {
-    //Check dates
-    if(start.after(expiry)){
-      //throw error
-      throw new InvalidOptionsException(new Throwable("start should be before expiry"));
+    // Hide default constructor
+    @SuppressWarnings("unused")
+    private Credentials() {
     }
-    if((long)(expiry.getTime() - start.getTime()) > (long) 31*24*60*60*1000){
-      //throw error
-      throw new InvalidOptionsException(new Throwable("Cannot exceed 31 days"));
-    }
-    Certificate cert = new Certificate(1,start,expiry,scopes,clientId, issuer);
-    //Create signature;
-    cert.generateSignature(accessToken);
-    String temporaryAccessToken = generateTemporaryAccessToken(accessToken, cert.seed);
-    return new Credentials(temporaryAccessToken, clientId, cert);
-  }
 
-  private static String generateTemporaryAccessToken(String accessToken, String seed){
-    try{
-      SecretKeySpec keySpec = new SecretKeySpec(accessToken.getBytes("utf-8"),algo);
-      Mac mac = Mac.getInstance(algo);
-      mac.init(keySpec);
-
-      return Base64.encodeBytes(mac.doFinal(seed.getBytes("utf-8")))
-      .replace('+','-')
-      .replace('/','_')
-      .replace("=","");
-    }catch (Exception e) {
-      e.printStackTrace();
-      return null;
+    public Credentials(String clientId, String accessToken, String certificate) {
+        this.clientId = clientId;
+        this.accessToken = accessToken;
+        this.certificate = certificate;
+        configureHawk();
     }
-  }
+
+    /*
+     * This method is used to generate unnamed temporary credentials
+     */
+    public Credentials createTemporaryCredentials(String[] scopes, Date start, Date expiry)
+            throws InvalidOptionsException {
+        return this.createTemporaryCredentials("", scopes, start, expiry);
+    }
+
+    public Credentials createTemporaryCredentials(String clientId, String[] scopes, Date start, Date expiry)
+            throws InvalidOptionsException {
+        // Check dates
+        if (start.after(expiry)) {
+            // throw error
+            throw new InvalidOptionsException(new Throwable("start should be before expiry"));
+        }
+        if ((long) (expiry.getTime() - start.getTime()) > (long) 31 * 24 * 60 * 60 * 1000) {
+            // throw error
+            throw new InvalidOptionsException(new Throwable("Cannot exceed 31 days"));
+        }
+        Certificate cert = new Certificate(1, start, expiry, scopes);
+        if (clientId != null && !clientId.equals("")) {
+            cert.issuer = this.clientId;
+        }
+        // Create signature;
+        cert.generateSignature(accessToken, clientId);
+        String temporaryAccessToken = generateTemporaryAccessToken(accessToken, cert.seed);
+        if (clientId != null && !clientId.equals("")) {
+            return new Credentials(clientId, temporaryAccessToken, cert.toString());
+        }
+        return new Credentials(this.clientId, temporaryAccessToken, cert.toString());
+    }
+
+    public static String generateTemporaryAccessToken(String accessToken, String seed) {
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(accessToken.getBytes("utf-8"), algo);
+            Mac mac = Mac.getInstance(algo);
+            mac.init(keySpec);
+
+            return Base64.encodeBytes(mac.doFinal(seed.getBytes("utf-8"))).replace('+', '-').replace('/', '_')
+                    .replace("=", "");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * GetExtAuthField generates the hawk ext header based on the
+     * authorizedScopes and the certificate used in the case of temporary
+     * credentials. The header is a base64 encoded json object with a
+     * "certificate" property set to the certificate of the temporary
+     * credentials and a "authorizedScopes" property set to the array of
+     * authorizedScopes, if provided. If either "certificate" or
+     * "authorizedScopes" is not supplied, they will be omitted from the json
+     * result. If neither are provided, an empty string is returned, rather than
+     * a base64 encoded representation of "null" or "{}". Hawk interprets the
+     * empty string as meaning the ext header is not needed.
+     *
+     * See: * http://docs.taskcluster.net/auth/authorized-scopes *
+     * http://docs.taskcluster.net/auth/temporary-credentials
+     */
+    private String GetExtAuthField() {
+        ExtAuthField extAuthField = new ExtAuthField(getCertificate(), authorizedScopes);
+        Gson gson = new Gson();
+        String ext = gson.toJson(extAuthField);
+        if (ext.equals("{}")) {
+            return "";
+        }
+        return Base64.encodeBytes(ext.getBytes());
+    }
+
+    public String generateAuthorizationHeader(URI uri, String method, String hash) {
+        return hawkClient.generateAuthorizationHeader(uri, method, hash, GetExtAuthField(), null, null);
+    }
+
+    public Certificate getCertificate() {
+        Gson gson = new Gson();
+        return gson.fromJson(certificate, Certificate.class);
+    }
+
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
 }

--- a/src/main/java/org/mozilla/taskcluster/client/ExtAuthField.java
+++ b/src/main/java/org/mozilla/taskcluster/client/ExtAuthField.java
@@ -1,0 +1,12 @@
+package org.mozilla.taskcluster.client;
+
+public class ExtAuthField {
+
+    public Certificate certificate;
+    public String[]    authorizedScopes;
+
+    public ExtAuthField(Certificate certificate, String[] authorizedScopes) {
+        this.certificate = certificate;
+        this.authorizedScopes = authorizedScopes;
+    }
+}

--- a/src/main/java/org/mozilla/taskcluster/client/InvalidOptionsException.java
+++ b/src/main/java/org/mozilla/taskcluster/client/InvalidOptionsException.java
@@ -1,7 +1,8 @@
 package org.mozilla.taskcluster.client;
 
+@SuppressWarnings("serial")
 public class InvalidOptionsException extends Exception {
-  public InvalidOptionsException (Throwable cause){
-    super(cause);
-  }
+    public InvalidOptionsException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/src/main/java/org/mozilla/taskcluster/client/auth/Auth.java
+++ b/src/main/java/org/mozilla/taskcluster/client/auth/Auth.java
@@ -70,6 +70,22 @@ public class Auth extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public Auth(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public Auth(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public Auth(String baseURL) {
+        super(baseURL);
+    }
+
+    public Auth() {
+        super(defaultBaseURL);
+    }
+
     /**
      * Get a list of all clients.  With `prefix`, only clients for which
      * it is a prefix of the clientId are returned.

--- a/src/main/java/org/mozilla/taskcluster/client/auth/Auth.java
+++ b/src/main/java/org/mozilla/taskcluster/client/auth/Auth.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.auth;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -61,20 +62,12 @@ public class Auth extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://auth.taskcluster.net/v1";
 
-    public Auth(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public Auth(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public Auth(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public Auth(String baseURL) {
-        super(baseURL);
-    }
-
-    public Auth() {
-        super(defaultBaseURL);
+    public Auth(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/awsprovisioner/AwsProvisioner.java
+++ b/src/main/java/org/mozilla/taskcluster/client/awsprovisioner/AwsProvisioner.java
@@ -53,6 +53,22 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public AwsProvisioner(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public AwsProvisioner(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public AwsProvisioner(String baseURL) {
+        super(baseURL);
+    }
+
+    public AwsProvisioner() {
+        super(defaultBaseURL);
+    }
+
     /**
      * Create a worker type.  A worker type contains all the configuration
      * needed for the provisioner to manage the instances.  Each worker type

--- a/src/main/java/org/mozilla/taskcluster/client/awsprovisioner/AwsProvisioner.java
+++ b/src/main/java/org/mozilla/taskcluster/client/awsprovisioner/AwsProvisioner.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.awsprovisioner;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -44,20 +45,12 @@ public class AwsProvisioner extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://aws-provisioner.taskcluster.net/v1";
 
-    public AwsProvisioner(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public AwsProvisioner(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public AwsProvisioner(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public AwsProvisioner(String baseURL) {
-        super(baseURL);
-    }
-
-    public AwsProvisioner() {
-        super(defaultBaseURL);
+    public AwsProvisioner(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/github/Github.java
+++ b/src/main/java/org/mozilla/taskcluster/client/github/Github.java
@@ -32,6 +32,22 @@ public class Github extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public Github(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public Github(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public Github(String baseURL) {
+        super(baseURL);
+    }
+
+    public Github() {
+        super(defaultBaseURL);
+    }
+
     /**
      * Capture a GitHub event and publish it via pulse, if it's a push
      * or pull request.

--- a/src/main/java/org/mozilla/taskcluster/client/github/Github.java
+++ b/src/main/java/org/mozilla/taskcluster/client/github/Github.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.github;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -23,20 +24,12 @@ public class Github extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://github.taskcluster.net/v1";
 
-    public Github(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public Github(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public Github(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public Github(String baseURL) {
-        super(baseURL);
-    }
-
-    public Github() {
-        super(defaultBaseURL);
+    public Github(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/hooks/Hooks.java
+++ b/src/main/java/org/mozilla/taskcluster/client/hooks/Hooks.java
@@ -40,6 +40,22 @@ public class Hooks extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public Hooks(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public Hooks(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public Hooks(String baseURL) {
+        super(baseURL);
+    }
+
+    public Hooks() {
+        super(defaultBaseURL);
+    }
+
     /**
      * This endpoint will return a list of all hook groups with at least one hook.
      *

--- a/src/main/java/org/mozilla/taskcluster/client/hooks/Hooks.java
+++ b/src/main/java/org/mozilla/taskcluster/client/hooks/Hooks.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.hooks;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -31,20 +32,12 @@ public class Hooks extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://hooks.taskcluster.net/v1";
 
-    public Hooks(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public Hooks(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public Hooks(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public Hooks(String baseURL) {
-        super(baseURL);
-    }
-
-    public Hooks() {
-        super(defaultBaseURL);
+    public Hooks(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/index/Index.java
+++ b/src/main/java/org/mozilla/taskcluster/client/index/Index.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.index;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -106,20 +107,12 @@ public class Index extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://index.taskcluster.net/v1";
 
-    public Index(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public Index(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public Index(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public Index(String baseURL) {
-        super(baseURL);
-    }
-
-    public Index() {
-        super(defaultBaseURL);
+    public Index(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/index/Index.java
+++ b/src/main/java/org/mozilla/taskcluster/client/index/Index.java
@@ -115,6 +115,22 @@ public class Index extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public Index(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public Index(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public Index(String baseURL) {
+        super(baseURL);
+    }
+
+    public Index() {
+        super(defaultBaseURL);
+    }
+
     /**
      * Find task by namespace, if no task existing for the given namespace, this
      * API end-point respond `404`.

--- a/src/main/java/org/mozilla/taskcluster/client/purgecache/PurgeCache.java
+++ b/src/main/java/org/mozilla/taskcluster/client/purgecache/PurgeCache.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.purgecache;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -23,20 +24,12 @@ public class PurgeCache extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://purge-cache.taskcluster.net/v1";
 
-    public PurgeCache(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public PurgeCache(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public PurgeCache(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public PurgeCache(String baseURL) {
-        super(baseURL);
-    }
-
-    public PurgeCache() {
-        super(defaultBaseURL);
+    public PurgeCache(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/purgecache/PurgeCache.java
+++ b/src/main/java/org/mozilla/taskcluster/client/purgecache/PurgeCache.java
@@ -32,6 +32,22 @@ public class PurgeCache extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public PurgeCache(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public PurgeCache(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public PurgeCache(String baseURL) {
+        super(baseURL);
+    }
+
+    public PurgeCache() {
+        super(defaultBaseURL);
+    }
+
     /**
      * Publish a purge-cache message to purge caches named `cacheName` with
      * `provisionerId` and `workerType` in the routing-key. Workers should

--- a/src/main/java/org/mozilla/taskcluster/client/queue/Queue.java
+++ b/src/main/java/org/mozilla/taskcluster/client/queue/Queue.java
@@ -35,6 +35,22 @@ public class Queue extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public Queue(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public Queue(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public Queue(String baseURL) {
+        super(baseURL);
+    }
+
+    public Queue() {
+        super(defaultBaseURL);
+    }
+
     /**
      * This end-point will return the task-definition. Notice that the task
      * definition may have been modified by queue, if an optional property isn't

--- a/src/main/java/org/mozilla/taskcluster/client/queue/Queue.java
+++ b/src/main/java/org/mozilla/taskcluster/client/queue/Queue.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.queue;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -26,20 +27,12 @@ public class Queue extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://queue.taskcluster.net/v1";
 
-    public Queue(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public Queue(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public Queue(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public Queue(String baseURL) {
-        super(baseURL);
-    }
-
-    public Queue() {
-        super(defaultBaseURL);
+    public Queue(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/scheduler/Scheduler.java
+++ b/src/main/java/org/mozilla/taskcluster/client/scheduler/Scheduler.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.scheduler;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -27,20 +28,12 @@ public class Scheduler extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://scheduler.taskcluster.net/v1";
 
-    public Scheduler(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public Scheduler(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public Scheduler(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public Scheduler(String baseURL) {
-        super(baseURL);
-    }
-
-    public Scheduler() {
-        super(defaultBaseURL);
+    public Scheduler(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/main/java/org/mozilla/taskcluster/client/scheduler/Scheduler.java
+++ b/src/main/java/org/mozilla/taskcluster/client/scheduler/Scheduler.java
@@ -36,6 +36,22 @@ public class Scheduler extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public Scheduler(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public Scheduler(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public Scheduler(String baseURL) {
+        super(baseURL);
+    }
+
+    public Scheduler() {
+        super(defaultBaseURL);
+    }
+
     /**
      * Create a new task-graph, the `status` of the resulting JSON is a
      * task-graph status structure, you can find the `taskGraphId` in this

--- a/src/main/java/org/mozilla/taskcluster/client/secrets/Secrets.java
+++ b/src/main/java/org/mozilla/taskcluster/client/secrets/Secrets.java
@@ -29,6 +29,22 @@ public class Secrets extends TaskClusterRequestHandler {
         super(credentials, baseURL);
     }
 
+    public Secrets(String clientId, String accessToken) {
+        super(new Credentials(clientId, accessToken), defaultBaseURL);
+    }
+
+    public Secrets(String clientId, String accessToken, String certificate) {
+        super(new Credentials(clientId, accessToken, certificate), defaultBaseURL);
+    }
+
+    public Secrets(String baseURL) {
+        super(baseURL);
+    }
+
+    public Secrets() {
+        super(defaultBaseURL);
+    }
+
     /**
      * Set a secret associated with some key.  If the secret already exists, it is updated instead.
      *

--- a/src/main/java/org/mozilla/taskcluster/client/secrets/Secrets.java
+++ b/src/main/java/org/mozilla/taskcluster/client/secrets/Secrets.java
@@ -6,6 +6,7 @@ package org.mozilla.taskcluster.client.secrets;
 
 import org.mozilla.taskcluster.client.APICallFailure;
 import org.mozilla.taskcluster.client.CallSummary;
+import org.mozilla.taskcluster.client.Credentials;
 import org.mozilla.taskcluster.client.EmptyPayload;
 import org.mozilla.taskcluster.client.TaskClusterRequestHandler;
 
@@ -20,20 +21,12 @@ public class Secrets extends TaskClusterRequestHandler {
 
     protected static final String defaultBaseURL = "https://secrets.taskcluster.net/v1";
 
-    public Secrets(String clientId, String accessToken) {
-        super(clientId, accessToken, defaultBaseURL);
+    public Secrets(Credentials credentials) {
+        super(credentials, defaultBaseURL);
     }
 
-    public Secrets(String clientId, String accessToken, String certificate) {
-        super(clientId, accessToken, certificate, defaultBaseURL);
-    }
-
-    public Secrets(String baseURL) {
-        super(baseURL);
-    }
-
-    public Secrets() {
-        super(defaultBaseURL);
+    public Secrets(Credentials credentials, String baseURL) {
+        super(credentials, baseURL);
     }
 
     /**

--- a/src/test/java/org/mozilla/taskcluster/APITest.java
+++ b/src/test/java/org/mozilla/taskcluster/APITest.java
@@ -56,8 +56,8 @@ public class APITest {
      */
     @Test
     public void findLatestBuildbotTask() {
-        Index index = new Index(null);
-        Queue queue = new Queue(null);
+        Index index = new Index();
+        Queue queue = new Queue();
         try {
             String taskId = index.findTask("buildbot.branches.mozilla-central.linux64.l10n").responsePayload.taskId;
             Date created = queue.task(taskId).responsePayload.created;
@@ -154,7 +154,9 @@ public class APITest {
 
     /*
      * This test checks static test cases of generating temporary credentials by
-     * looking up known results for a range of test cases
+     * looking up known results for a range of test cases.
+     *
+     * TODO: Add tests that call auth endpoints: https://bugzilla.mozilla.org/show_bug.cgi?id=1257520
      */
     @Test
     public void createTemporaryCredentials() {
@@ -170,7 +172,7 @@ public class APITest {
                 Date start = sdf.parse(tc.start);
                 Date expiry = sdf.parse(tc.expiry);
 
-                Credentials permCreds = new Credentials(tc.permCreds.clientId, tc.permCreds.accessToken, null);
+                Credentials permCreds = new Credentials(tc.permCreds.clientId, tc.permCreds.accessToken);
                 Credentials tempCreds = permCreds.createTemporaryCredentials(tc.tempCredsName, tc.tempCredsScopes,
                         start, expiry);
                 Certificate cert = tempCreds.getCertificate();

--- a/src/test/java/org/mozilla/taskcluster/TempCredsTestCase.java
+++ b/src/test/java/org/mozilla/taskcluster/TempCredsTestCase.java
@@ -1,0 +1,14 @@
+package org.mozilla.taskcluster;
+
+import org.mozilla.taskcluster.client.Credentials;
+
+public class TempCredsTestCase {
+    public String      description;
+    public Credentials permCreds;
+    public String      seed;
+    public String      start;
+    public String      expiry;
+    public String      tempCredsName;
+    public String[]    tempCredsScopes;
+    public Credentials expectedTempCreds;
+}

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,2 @@
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=FINEST

--- a/src/test/resources/testcases.json
+++ b/src/test/resources/testcases.json
@@ -1,0 +1,102 @@
+[
+  {
+    "description": "Unnamed Temp Creds with no Authorized Scopes",
+    "expectedTempCreds": {
+      "accessToken": "R4OVHWpIvy6KsqS4AWE51QwbvgLvsstS6e6UW8IfHUY",
+      "authorizedScopes": null,
+      "certificate": "{\"version\":1,\"scopes\":[\"scope/asd:fhjdf/X\",\"scope/asd:fhjdf/XYZ*\"],\"start\":1438964811744,\"expiry\":1439051211744,\"seed\":\"JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ\",\"signature\":\"45AlB/hKZZZz4Tf3NaidutasfgBnr4t2AxwBiGDQF9Q=\"}",
+      "clientId": "def/ghi@XXX"
+    },
+    "expiry": "2015-08-08T16:26:51.744Z",
+    "permCreds": {
+      "accessToken": "tokenABCDEFGH",
+      "authorizedScopes": null,
+      "certificate": "",
+      "clientId": "def/ghi@XXX"
+    },
+    "seed": "JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ",
+    "start": "2015-08-07T16:26:51.744Z",
+    "tempCredsName": "",
+    "tempCredsScopes": [
+      "scope/asd:fhjdf/X",
+      "scope/asd:fhjdf/XYZ*"
+    ]
+  },
+  {
+    "description": "Named Temp Creds with no Authorized Scopes",
+    "expectedTempCreds": {
+      "accessToken": "R4OVHWpIvy6KsqS4AWE51QwbvgLvsstS6e6UW8IfHUY",
+      "authorizedScopes": null,
+      "certificate": "{\"version\":1,\"scopes\":[\"scope/asd:fhjdf/X\",\"scope/asd:fhjdf/XYZ*\"],\"start\":1438964811744,\"expiry\":1439051211744,\"seed\":\"JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ\",\"signature\":\"nNEaLtZMiw627NuDbF5Z8HDFc57MGWCptXBQSYNFgBk=\",\"issuer\":\"def/ghi@XXX\"}",
+      "clientId": "abc/def/ghi"
+    },
+    "expiry": "2015-08-08T16:26:51.744Z",
+    "permCreds": {
+      "accessToken": "tokenABCDEFGH",
+      "authorizedScopes": null,
+      "certificate": "",
+      "clientId": "def/ghi@XXX"
+    },
+    "seed": "JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ",
+    "start": "2015-08-07T16:26:51.744Z",
+    "tempCredsName": "abc/def/ghi",
+    "tempCredsScopes": [
+      "scope/asd:fhjdf/X",
+      "scope/asd:fhjdf/XYZ*"
+    ]
+  },
+  {
+    "description": "Unnamed Temp Creds with Authorized Scopes",
+    "expectedTempCreds": {
+      "accessToken": "R4OVHWpIvy6KsqS4AWE51QwbvgLvsstS6e6UW8IfHUY",
+      "authorizedScopes": [
+        "scope/asd:fhjdf/X"
+      ],
+      "certificate": "{\"version\":1,\"scopes\":[\"scope/asd:fhjdf/X\",\"scope/asd:fhjdf/XYZ*\"],\"start\":1438964811744,\"expiry\":1439051211744,\"seed\":\"JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ\",\"signature\":\"45AlB/hKZZZz4Tf3NaidutasfgBnr4t2AxwBiGDQF9Q=\"}",
+      "clientId": "def/ghi@XXX"
+    },
+    "expiry": "2015-08-08T16:26:51.744Z",
+    "permCreds": {
+      "accessToken": "tokenABCDEFGH",
+      "authorizedScopes": [
+        "scope/asd:fhjdf/X"
+      ],
+      "certificate": "",
+      "clientId": "def/ghi@XXX"
+    },
+    "seed": "JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ",
+    "start": "2015-08-07T16:26:51.744Z",
+    "tempCredsName": "",
+    "tempCredsScopes": [
+      "scope/asd:fhjdf/X",
+      "scope/asd:fhjdf/XYZ*"
+    ]
+  },
+  {
+    "description": "Named Temp Creds with Authorized Scopes",
+    "expectedTempCreds": {
+      "accessToken": "R4OVHWpIvy6KsqS4AWE51QwbvgLvsstS6e6UW8IfHUY",
+      "authorizedScopes": [
+        "scope/asd:fhjdf/X"
+      ],
+      "certificate": "{\"version\":1,\"scopes\":[\"scope/asd:fhjdf/X\",\"scope/asd:fhjdf/XYZ*\"],\"start\":1438964811744,\"expiry\":1439051211744,\"seed\":\"JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ\",\"signature\":\"nNEaLtZMiw627NuDbF5Z8HDFc57MGWCptXBQSYNFgBk=\",\"issuer\":\"def/ghi@XXX\"}",
+      "clientId": "abc/def/ghi"
+    },
+    "expiry": "2015-08-08T16:26:51.744Z",
+    "permCreds": {
+      "accessToken": "tokenABCDEFGH",
+      "authorizedScopes": [
+        "scope/asd:fhjdf/X"
+      ],
+      "certificate": "",
+      "clientId": "def/ghi@XXX"
+    },
+    "seed": "JYR4wzMCTG6XeDS2cDUCMwH0RFUXGfQjK7LgqD-e6lSQ",
+    "start": "2015-08-07T16:26:51.744Z",
+    "tempCredsName": "abc/def/ghi",
+    "tempCredsScopes": [
+      "scope/asd:fhjdf/X",
+      "scope/asd:fhjdf/XYZ*"
+    ]
+  }
+]


### PR DESCRIPTION
I couldn't help myself, and decided to clean this up.

It is now much more consistent with the go implementation, and there are a bunch of fixes.

Of note, I checked in some static test cases - see the testcases.json file. I'm using an identical test cases file in the java and the go client, to check they produce identical results.

I haven't yet updated the java client to use the test auth endpoints - I figured there was some value in having static tests for the temp creds generation with a static start date and end date - maybe this could also have been achieved hitting the endpoints - but I figured if there is a problem when hitting an auth test endpoint, it could be either a) generation of temp credentials or b) usage of temp credentials in http transport, so it still had some value to keep these static tests.

We could upload the testcases.json file somewhere neutral - at the moment I have it checked into both taskcluster-client-java and taskcluster-client-go repositories.