### PR TITLE
Rewrite to work with jsonschema2go to avoid duplicated logic

### DIFF
--- a/codegenerator/model/apis.json
+++ b/codegenerator/model/apis.json
@@ -1,67 +1,54 @@
 [
     {
         "url": "http://references.taskcluster.net/auth/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/platform/auth/api-docs"
     }, {
         "url": "http://references.taskcluster.net/auth/v1/exchanges.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/exchanges-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/platform/auth/exchanges"
     }, {
         "url": "http://references.taskcluster.net/aws-provisioner/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/aws-provisioner/api-docs"
     }, {
         "url": "http://references.taskcluster.net/aws-provisioner/v1/exchanges.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/exchanges-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/aws-provisioner/exchanges"
     }, {
         "url": "http://references.taskcluster.net/github/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/github/api-docs"
     }, {
         "url": "http://references.taskcluster.net/github/v1/exchanges.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/exchanges-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/github/exchanges"
     }, {
         "url": "http://references.taskcluster.net/hooks/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/hooks/api-docs"
     }, {
         "url": "http://references.taskcluster.net/index/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/index/api-docs"
     }, {
         "url": "http://references.taskcluster.net/login/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/login/api-docs"
     }, {
         "url": "http://references.taskcluster.net/purge-cache/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/purge-cache/api-docs"
     }, {
         "url": "http://references.taskcluster.net/purge-cache/v1/exchanges.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/exchanges-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/purge-cache/exchanges"
     }, {
         "url": "http://references.taskcluster.net/queue/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/platform/queue/api-docs"
     }, {
         "url": "http://references.taskcluster.net/queue/v1/exchanges.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/exchanges-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/platform/queue/exchanges"
     }, {
         "url": "http://references.taskcluster.net/scheduler/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/platform/scheduler/api-docs"
     }, {
         "url": "http://references.taskcluster.net/scheduler/v1/exchanges.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/exchanges-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/platform/scheduler/exchanges"
     }, {
         "url": "http://references.taskcluster.net/secrets/v1/api.json",
-        "schema": "http://schemas.taskcluster.net/base/v1/api-reference.json",
         "docroot": "https://docs.taskcluster.net/reference/core/secrets/api-docs"
+    }, {
+        "url": "http://references.taskcluster.net/taskcluster-treeherder/v1/exchanges.json",
+        "docroot": "https://docs.taskcluster.net/reference/core/treeherder/exchanges"
     }
 ]

--- a/codegenerator/model/exchange.go
+++ b/codegenerator/model/exchange.go
@@ -1,8 +1,6 @@
 package model
 
-import (
-	"fmt"
-)
+import "fmt"
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -59,7 +57,7 @@ type ExchangeEntry struct {
 }
 
 func (entry *ExchangeEntry) postPopulate(apiDef *APIDefinition) {
-	entry.Payload = entry.Parent.apiDef.cacheJsonSchema(&entry.Schema)
+	entry.Parent.apiDef.schemaURLs = append(entry.Parent.apiDef.schemaURLs, entry.Schema)
 }
 
 func (entry *ExchangeEntry) String() string {

--- a/codegenerator/model/jsonschema.go
+++ b/codegenerator/model/jsonschema.go
@@ -1,122 +1,95 @@
 package model
 
 import (
-	"encoding/json"
 	"fmt"
-	"reflect"
-	"sort"
+	"log"
+	"net/url"
 	"strconv"
 	"strings"
 
+	"github.com/taskcluster/jsonschema2go"
 	"github.com/taskcluster/taskcluster-client-java/codegenerator/utils"
 )
 
-type (
-	// Note that all members are backed by pointers, so that nil value can signify non-existence.
-	// Otherwise we could not differentiate whether a zero value is non-existence or actually the
-	// zero value. For example, if a bool is false, we don't know if it was explictly set to false
-	// in the json we read, or whether it was not given. Unmarshaling into a pointer means pointer
-	// will be nil pointer if it wasn't read, or a pointer to true/false if it was read from json.
-	JsonSubSchema struct {
-		AdditionalItems      *bool                 `json:"additionalItems"`
-		AdditionalProperties *AdditionalProperties `json:"additionalProperties"`
-		AllOf                Items                 `json:"allOf"`
-		AnyOf                Items                 `json:"anyOf"`
-		Default              *interface{}          `json:"default"`
-		Description          *string               `json:"description"`
-		Enum                 interface{}           `json:"enum"`
-		Format               *string               `json:"format"`
-		ID                   *string               `json:"id"`
-		Items                *JsonSubSchema        `json:"items"`
-		Maximum              *int                  `json:"maximum"`
-		MaxLength            *int                  `json:"maxLength"`
-		Minimum              *int                  `json:"minimum"`
-		MinLength            *int                  `json:"minLength"`
-		OneOf                Items                 `json:"oneOf"`
-		Pattern              *string               `json:"pattern"`
-		Properties           *Properties           `json:"properties"`
-		Ref                  *string               `json:"$ref"`
-		Required             []string              `json:"required"`
-		Schema               *string               `json:"$schema"`
-		Title                *string               `json:"title"`
-		Type                 *string               `json:"type"`
+type JsonSubSchema jsonschema2go.JsonSubSchema
 
-		// non-json fields used for sorting/tracking
-		TypeName       string
-		IsInputSchema  bool
-		IsOutputSchema bool
-		SourceURL      string
-		RefSubSchema   *JsonSubSchema
-		APIDefinition  *APIDefinition
+func (jsonSubSchema *JsonSubSchema) TypeDefinition(level int, extraPackages map[string]bool) (classDefinition, comment, typ string) {
+	if d := jsonSubSchema.Description; d != nil {
+		if desc := *d; desc != "" {
+			comment += desc
+		}
+	}
+	if comment != "" && comment[len(comment)-1:] != "\n" {
+		comment += "\n"
 	}
 
-	Items []JsonSubSchema
-
-	Properties struct {
-		Properties          map[string]*JsonSubSchema
-		SortedPropertyNames []string
-	}
-
-	AdditionalProperties struct {
-		Boolean    *bool
-		Properties *JsonSubSchema
-	}
-)
-
-func (subSchema JsonSubSchema) String() string {
-	result := ""
-	result += describe("Additional Items", subSchema.AdditionalItems)
-	result += describe("Additional Properties", subSchema.AdditionalProperties)
-	result += describe("All Of", subSchema.AllOf)
-	result += describe("Any Of", subSchema.AnyOf)
-	result += describe("Default", subSchema.Default)
-	result += describe("Description", subSchema.Description)
-	result += describe("Enum", subSchema.Enum)
-	result += describe("Format", subSchema.Format)
-	result += describe("ID", subSchema.ID)
-	result += describeList("Items", subSchema.Items)
-	result += describe("Maximum", subSchema.Maximum)
-	result += describe("MaxLength", subSchema.MaxLength)
-	result += describe("Minimum", subSchema.Minimum)
-	result += describe("MinLength", subSchema.MinLength)
-	result += describeList("OneOf", subSchema.OneOf)
-	result += describe("Pattern", subSchema.Pattern)
-	result += describeList("Properties", subSchema.Properties)
-	result += describe("Ref", subSchema.Ref)
-	result += describe("Required", subSchema.Required)
-	result += describe("Schema", subSchema.Schema)
-	result += describe("Title", subSchema.Title)
-	result += describe("Type", subSchema.Type)
-	result += describe("TypeName", &subSchema.TypeName)
-	result += describe("IsInputSchema", &subSchema.IsInputSchema)
-	result += describe("IsOutputSchema", &subSchema.IsOutputSchema)
-	result += describe("SourceURL", &subSchema.SourceURL)
-	return result
-}
-
-func (jsonSubSchema *JsonSubSchema) TypeDefinition(level int, fromArray bool, extraPackages map[string]bool) (string, map[string]bool, string) {
-	content := ""
-	if level == 0 && !fromArray {
-		content += "/**\n"
-		if d := jsonSubSchema.Description; d != nil {
-			if desc := *d; desc != "" {
-				content += utils.Indent(desc, "* ")
-			}
-			if content[len(content)-1:] != "\n" {
-				content += "\n"
+	// Create comments for metadata in a single paragraph. Only start new
+	// paragraph if we discover after inspecting all possible metadata, that
+	// something has been specified. If there is no metadata, no need to create
+	// a new paragraph.
+	var metadata string
+	if enum := jsonSubSchema.Enum; enum != nil {
+		metadata += "Possible values:\n"
+		for _, i := range enum {
+			switch i.(type) {
+			case float64:
+				metadata += fmt.Sprintf("    * %v\n", i)
+			default:
+				metadata += fmt.Sprintf("    * %q\n", i)
 			}
 		}
-		if url := jsonSubSchema.SourceURL; url != "" {
-			content += "*\n* See " + url + "\n"
-		}
-		content += "*/\n"
 	}
-	typ := "Object"
+	if def := jsonSubSchema.Default; def != nil {
+		var value string
+		switch (*def).(type) {
+		case bool:
+			value = strconv.FormatBool((*def).(bool))
+		case float64:
+			value = strconv.FormatFloat((*def).(float64), 'g', -1, 64)
+		default:
+			value = fmt.Sprintf("%q", *def)
+		}
+		metadata += "Default:    " + value + "\n"
+	}
+	if regex := jsonSubSchema.Pattern; regex != nil {
+		metadata += "Syntax:     " + *regex + "\n"
+	}
+	if minItems := jsonSubSchema.MinLength; minItems != nil {
+		metadata += "Min length: " + strconv.Itoa(*minItems) + "\n"
+	}
+	if maxItems := jsonSubSchema.MaxLength; maxItems != nil {
+		metadata += "Max length: " + strconv.Itoa(*maxItems) + "\n"
+	}
+	if minimum := jsonSubSchema.Minimum; minimum != nil {
+		metadata += "Mininum:    " + strconv.Itoa(*minimum) + "\n"
+	}
+	if maximum := jsonSubSchema.Maximum; maximum != nil {
+		metadata += "Maximum:    " + strconv.Itoa(*maximum) + "\n"
+	}
+	// Here we check if metadata was specified, and only create new
+	// paragraph (`*\n`) if something was.
+	if len(metadata) > 0 {
+		comment += "\n" + metadata
+	}
+
+	if URL := jsonSubSchema.SourceURL; URL != "" {
+		u, err := url.Parse(URL)
+		if err == nil && u.Scheme != "file" {
+			if len(comment) > 1 {
+				comment += "\n"
+			}
+			comment += "See " + URL + "\n"
+		}
+	}
+	comment = utils.Comment(comment, "")
+
+	typ = "Object"
 	if p := jsonSubSchema.Type; p != nil {
 		typ = *p
 	}
 	if p := jsonSubSchema.RefSubSchema; p != nil {
-		_, _, possSimpleType := p.TypeDefinition(1, true, make(map[string]bool))
+		j := JsonSubSchema(*jsonSubSchema.RefSubSchema)
+		_, _, possSimpleType := (&j).TypeDefinition(0, make(map[string]bool))
 		switch possSimpleType {
 		case "":
 			typ = p.TypeName
@@ -126,44 +99,47 @@ func (jsonSubSchema *JsonSubSchema) TypeDefinition(level int, fromArray bool, ex
 	}
 	switch typ {
 	case "array":
-		if jsonType := jsonSubSchema.Items.Type; jsonType != nil {
-			var newType string
-			newType, extraPackages, typ = jsonSubSchema.Items.TypeDefinition(level, true, extraPackages)
-			if level == 0 {
-				if typ == "" {
-					content += newType
+		if jsonSubSchema.Items != nil {
+			if jsonSubSchema.Items.Type != nil {
+				j := JsonSubSchema(*jsonSubSchema.Items)
+				subClassDefinition, _, subType := (&j).TypeDefinition(level, extraPackages)
+				if subType == "" {
+					log.Fatalf("%v returns an empty Type", jsonSubSchema.Items.SourceURL)
 				}
+				typ = subType + "[]"
+				classDefinition = subClassDefinition
+
 			} else {
-				typ = newType + "[]"
+				if refSubSchema := jsonSubSchema.Items.RefSubSchema; refSubSchema != nil {
+					if refSubSchema.TypeName == "" {
+						log.Fatalf("%v has not set TypeName", refSubSchema.SourceURL)
+					}
+					typ = refSubSchema.TypeName + "[]"
+				}
 			}
 		} else {
-			if refSubSchema := jsonSubSchema.Items.RefSubSchema; refSubSchema != nil {
-				typ = refSubSchema.TypeName
-			}
+			typ = "Object[]"
 		}
 
 	case "object":
 		if s := jsonSubSchema.Properties; s != nil {
-			typ = "" // strings.Title(jsonSubSchema.TypeName)
-			def := fmt.Sprintf("class " + strings.Title(jsonSubSchema.TypeName) + " {\n")
+			typ = jsonSubSchema.TypeName
+			classDefinition = "\n" + strings.Repeat("    ", level) + "public class " + typ + " {"
 			for _, j := range s.SortedPropertyNames {
 				// recursive call to build go types inside structs
 				var subType string
-				subType, extraPackages, _ = s.Properties[j].TypeDefinition(level+1, false, extraPackages)
-				// comment the struct member with the description from the json
-				if d := s.Properties[j].Description; d != nil {
-					def += "\n" + utils.Comment(*d, strings.Repeat("    ", level+1))
-				}
-				// struct member name and type, as part of struct definition
-				def += fmt.Sprintf(strings.Repeat("    ", level+1)+"public %v %v;\n", subType, s.Properties[j].TypeName)
+				c := JsonSubSchema(*s.Properties[j])
+				subMember := s.MemberNames[j]
+				subClassDefinition, subComment, subType := (&c).TypeDefinition(level+1, extraPackages)
+				classDefinition += "\n"
+				classDefinition += subClassDefinition
+				classDefinition += "\n"
+				classDefinition += utils.Indent(subComment, strings.Repeat("    ", level+1), false)
+				classDefinition += strings.Repeat("    ", level+1) + "public " + subType + " " + subMember + ";"
 			}
-			def += strings.Repeat("    ", level) + "}"
-			if level == 0 {
-				def = "public " + def
-			} else {
-				def += "\n\n" + strings.Repeat("    ", level) + "public " + strings.Title(jsonSubSchema.TypeName)
-			}
-			content += def
+			classDefinition += "\n"
+			classDefinition += strings.Repeat("    ", level) + "}"
+			classDefinition += "\n"
 		} else {
 			typ = "Object"
 		}
@@ -186,130 +162,5 @@ func (jsonSubSchema *JsonSubSchema) TypeDefinition(level int, fromArray bool, ex
 	case "Date":
 		extraPackages["java.util.Date"] = true
 	}
-	content += typ
-	return content, extraPackages, typ
-}
-
-func (p Properties) String() string {
-	result := ""
-	for _, i := range p.SortedPropertyNames {
-		result += "Property '" + i + "' =\n" + utils.Indent(p.Properties[i].String(), "  ")
-	}
-	return result
-}
-
-func (p *Properties) postPopulate(apiDef *APIDefinition) {
-	// now all data should be loaded, let's sort the p.Properties
-	if p.Properties != nil {
-		p.SortedPropertyNames = make([]string, 0, len(p.Properties))
-		for propertyName := range p.Properties {
-			p.SortedPropertyNames = append(p.SortedPropertyNames, propertyName)
-		}
-		sort.Strings(p.SortedPropertyNames)
-		members := make(map[string]bool, len(p.SortedPropertyNames))
-		for _, j := range p.SortedPropertyNames {
-			p.Properties[j].TypeName = utils.NormaliseLower(j, members)
-			// subschemas also need to be triggered to postPopulate...
-			p.Properties[j].postPopulate(apiDef)
-		}
-	}
-}
-
-func (p *Properties) UnmarshalJSON(bytes []byte) (err error) {
-	errX := json.Unmarshal(bytes, &p.Properties)
-	return errX
-}
-
-func (aP *AdditionalProperties) UnmarshalJSON(bytes []byte) (err error) {
-	b, p := new(bool), new(JsonSubSchema)
-	if err = json.Unmarshal(bytes, b); err == nil {
-		aP.Boolean = b
-		return
-	}
-	if err = json.Unmarshal(bytes, p); err == nil {
-		aP.Properties = p
-	}
-	return
-}
-
-func (aP AdditionalProperties) String() string {
-	if aP.Boolean != nil {
-		return strconv.FormatBool(*aP.Boolean)
-	}
-	return aP.Properties.String()
-}
-
-func (items Items) String() string {
-	result := ""
-	for i, j := range items {
-		result += fmt.Sprintf("Item '%v' =\n", i) + utils.Indent(j.String(), "  ")
-	}
-	return result
-}
-
-func (items Items) postPopulate(apiDef *APIDefinition) {
-	for i := range items {
-		items[i].postPopulate(apiDef)
-	}
-}
-
-func describeList(name string, value interface{}) string {
-	if reflect.ValueOf(value).IsValid() {
-		if !reflect.ValueOf(value).IsNil() {
-			return fmt.Sprintf("%v\n", name) + utils.Indent(fmt.Sprintf("%v", reflect.Indirect(reflect.ValueOf(value)).Interface()), "  ")
-		}
-	}
-	return ""
-}
-
-// If item is not null, then return a description of it. If it is a pointer, dereference it first.
-func describe(name string, value interface{}) string {
-	if reflect.ValueOf(value).IsValid() {
-		if !reflect.ValueOf(value).IsNil() {
-			return fmt.Sprintf("%-22v = '%v'\n", name, reflect.Indirect(reflect.ValueOf(value)).Interface())
-		}
-	}
-	return ""
-}
-
-type CanPopulate interface {
-	postPopulate(*APIDefinition)
-}
-
-func postPopulateIfNotNil(canPopulate CanPopulate, apiDef *APIDefinition) {
-	if reflect.ValueOf(canPopulate).IsValid() {
-		if !reflect.ValueOf(canPopulate).IsNil() {
-			canPopulate.postPopulate(apiDef)
-		}
-	}
-}
-
-func (subSchema *JsonSubSchema) postPopulate(apiDef *APIDefinition) {
-	if subSchema.TypeName == "" {
-		members := make(map[string]bool, 1)
-		switch {
-		case subSchema.Title != nil && *subSchema.Title != "" && len(*subSchema.Title) < 40:
-			subSchema.TypeName = utils.NormaliseLower(*subSchema.Title, members)
-		case subSchema.Description != nil && *subSchema.Description != "" && len(*subSchema.Description) < 40:
-			subSchema.TypeName = utils.NormaliseLower(*subSchema.Description, members)
-		case subSchema.RefSubSchema != nil && subSchema.RefSubSchema.TypeName != "":
-			subSchema.TypeName = subSchema.RefSubSchema.TypeName
-		default:
-			subSchema.TypeName = "X"
-		}
-	}
-	// Arrays should get their name from their parent subschema. Note we set
-	// this before calling postPopulate on subSchema.Items, to make sure we get
-	// there first! If already set, it won't get updated later.
-	if subSchema.Items != nil {
-		subSchema.Items.TypeName = subSchema.TypeName
-	}
-	postPopulateIfNotNil(subSchema.AllOf, apiDef)
-	postPopulateIfNotNil(subSchema.AnyOf, apiDef)
-	postPopulateIfNotNil(subSchema.OneOf, apiDef)
-	postPopulateIfNotNil(subSchema.Items, apiDef)
-	postPopulateIfNotNil(subSchema.Properties, apiDef)
-	// If we have a $ref pointing to another schema, keep a reference so we can
-	// discover TypeName later when we generate the type definition
-	subSchema.RefSubSchema = apiDef.cacheJsonSchema(subSchema.Ref)
+	return classDefinition, comment, typ
 }

--- a/codegenerator/utils/utils.go
+++ b/codegenerator/utils/utils.go
@@ -9,10 +9,12 @@ import (
 )
 
 // indents a block of text with an indent string, see http://play.golang.org/p/nV1_VLau7C
-func Indent(text, indent string) string {
-	text = strings.Replace(text, "*/", "* /", -1)
+func Indent(text, indent string, escapeText bool) string {
 	if text == "" {
 		return text
+	}
+	if escapeText {
+		text = strings.Replace(text, "*/", "* /", -1)
 	}
 	if text[len(text)-1:] == "\n" {
 		result := ""
@@ -140,10 +142,14 @@ func Comment(text, indent string) string {
 		return text
 	}
 	comment := indent + "/**\n"
-	comment += Indent(text, indent+" * ")
+	comment += Indent(text, indent+" * ", true)
 	if comment[len(comment)-1:] != "\n" {
 		comment += "\n"
 	}
 	comment += indent + " */\n"
-	return comment
+	trimmed := strings.Split(comment, "\n")
+	for i, t := range trimmed {
+		trimmed[i] = strings.TrimRight(t, " ")
+	}
+	return strings.Join(trimmed, "\n")
 }


### PR DESCRIPTION
This was kinda needed, as the code base for taskcluster-client-go and taskcluster-client-java was drifting. It still isn't perfect, but now at least the interpretation of the json is shared.