### PR TITLE
Bug 1484702 - handle trailing and non-trailing / in baseURL

### DIFF
--- a/src/main/java/org/mozilla/taskcluster/client/TaskclusterRequestHandler.java
+++ b/src/main/java/org/mozilla/taskcluster/client/TaskclusterRequestHandler.java
@@ -113,7 +113,13 @@ public abstract class TaskclusterRequestHandler {
                 // Base64.encodeBytes(messageDigest.digest());
                 String hash = null;
 
-                URI uri = new URI(baseURL + route);
+                // Avoid double / between baseURL and route
+                String url = baseURL;
+                if (!url.endsWith("/")) {
+                    url += "/";
+                }
+                url += route;
+                URI uri = new URI(url);
                 if (credentials != null && authenticate) {
                     String authorizationHeader = credentials.generateAuthorizationHeader(uri, method, hash);
                     HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
I think we need this for backward compatibility while services are being upgraded.