### PR TITLE
Bug 1428422 - reenable treeherder events code generation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,6 @@ rm -rf src/main/java/org/mozilla/taskcluster/client/*/*.java
 git checkout -f src/main/java/org/mozilla/taskcluster/client/awsprovisioner/
 git checkout -f src/main/java/org/mozilla/taskcluster/client/awsprovisionerevents/
 git checkout -f src/main/java/org/mozilla/taskcluster/client/ec2manager/
-git checkout -f src/main/java/org/mozilla/taskcluster/client/treeherderevents/
 
 rm -rf "${GOPATH}/bin/generatemodel"
 rm -rf "${GOPATH}"/pkg/*/github.com/*/taskcluster-client-java

--- a/codegenerator/model/apis.json
+++ b/codegenerator/model/apis.json
@@ -38,5 +38,8 @@
     }, {
         "url": "https://references.taskcluster.net/secrets/v1/api.json",
         "docroot": "https://docs.taskcluster.net/reference/core/secrets/api-docs"
+    }, {
+        "url": "https://references.taskcluster.net/treeherder/v1/exchanges.json",
+        "docroot": "https://docs.taskcluster.net/reference/core/treeherder/exchanges"
     }
 ]

--- a/codegenerator/model/model-data.txt
+++ b/codegenerator/model/model-data.txt
@@ -28213,3 +28213,1861 @@ title: Secret
 type: object
 
 
+https://references.taskcluster.net/treeherder/v1/exchanges.json
+===============================================================
+Version         = '0'
+Title           = 'Taskcluster-treeherder Pulse Exchange'
+Description     = 'The taskcluster-treeherder service is responsible for processing
+task events published by TaskCluster Queue and producing job messages
+that are consumable by Treeherder.
+
+This exchange provides that job messages to be consumed by any queue that
+attached to the exchange.  This could be a production Treeheder instance,
+a local development environment, or a custom dashboard.'
+Exchange Prefix = 'exchange/taskcluster-treeherder/v1/'
+Entry 0     = 
+    Entry Type        = 'topic-exchange'
+    Entry Exchange    = 'jobs'
+    Entry Name        = 'jobs'
+    Entry Title       = 'Job Messages'
+    Entry Description = 'When a task run is scheduled or resolved, a message is posted to
+this exchange in a Treeherder consumable format.'
+    Routing Key Element 0     = 
+        Element Name      = 'destination'
+        Element Summary   = 'destination'
+        Element Constant  = ''
+        Element M Words   = 'false'
+        Element Required  = 'true'
+    Routing Key Element 1     = 
+        Element Name      = 'project'
+        Element Summary   = 'project'
+        Element Constant  = ''
+        Element M Words   = 'false'
+        Element Required  = 'true'
+    Routing Key Element 2     = 
+        Element Name      = 'reserved'
+        Element Summary   = 'Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.'
+        Element Constant  = ''
+        Element M Words   = 'true'
+        Element Required  = 'false'
+    Entry Schema      = 'v1/pulse-job.json#'
+    Entry SchemaURL   = 'https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#'
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#
+=============================================================
+$id: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#
+$schema: http://json-schema.org/draft-06/schema#
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#
+TYPE_NAME: JobDefinition
+additionalProperties:
+  Boolean: false
+  Properties: null
+definitions:
+  MemberNames:
+    machine: machine
+  Properties:
+    machine:
+      IS_REQUIRED: false
+      PROPERTY_NAME: machine
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
+      TYPE_NAME: Machine
+      additionalProperties:
+        Boolean: false
+        Properties: null
+      properties:
+        MemberNames:
+          architecture: architecture
+          name: name
+          os: os
+          platform: platform
+        Properties:
+          architecture:
+            IS_REQUIRED: true
+            PROPERTY_NAME: architecture
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/architecture
+            TYPE_NAME: ""
+            maxLength: 25
+            minLength: 1
+            pattern: ^[\w-]+$
+            type: string
+          name:
+            IS_REQUIRED: false
+            PROPERTY_NAME: name
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/name
+            TYPE_NAME: ""
+            maxLength: 50
+            minLength: 1
+            pattern: ^[\w-]+$
+            type: string
+          os:
+            IS_REQUIRED: true
+            PROPERTY_NAME: os
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/os
+            TYPE_NAME: ""
+            maxLength: 25
+            minLength: 1
+            pattern: ^[\w-]+$
+            type: string
+          platform:
+            IS_REQUIRED: true
+            PROPERTY_NAME: platform
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/platform
+            TYPE_NAME: ""
+            maxLength: 100
+            minLength: 1
+            pattern: ^[\w-]+$
+            type: string
+        SortedPropertyNames:
+        - architecture
+        - name
+        - os
+        - platform
+        SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties
+      required:
+      - platform
+      - os
+      - architecture
+      type: object
+  SortedPropertyNames:
+  - machine
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions
+description: |
+  Definition of a single job that can be added to Treeherder
+  Project is determined by the routing key, so we don't need to specify it here.
+properties:
+  MemberNames:
+    buildMachine: buildMachine
+    buildSystem: buildSystem
+    coalesced: coalesced
+    display: display
+    extra: extra
+    isRetried: isRetried
+    jobInfo: jobInfo
+    jobKind: jobKind
+    labels: labels
+    logs: logs
+    origin: origin
+    owner: owner
+    productName: productName
+    reason: reason
+    result: result
+    retryId: retryId
+    runMachine: runMachine
+    state: state
+    taskId: taskId
+    tier: tier
+    timeCompleted: timeCompleted
+    timeScheduled: timeScheduled
+    timeStarted: timeStarted
+    version: version
+  Properties:
+    buildMachine:
+      $ref: '#/definitions/machine'
+      IS_REQUIRED: false
+      PROPERTY_NAME: buildMachine
+      REF_SCHEMA_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
+      REF_SUBSCHEMA:
+        IS_REQUIRED: false
+        PROPERTY_NAME: machine
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
+        TYPE_NAME: Machine
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        properties:
+          MemberNames:
+            architecture: architecture
+            name: name
+            os: os
+            platform: platform
+          Properties:
+            architecture:
+              IS_REQUIRED: true
+              PROPERTY_NAME: architecture
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/architecture
+              TYPE_NAME: ""
+              maxLength: 25
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+            name:
+              IS_REQUIRED: false
+              PROPERTY_NAME: name
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/name
+              TYPE_NAME: ""
+              maxLength: 50
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+            os:
+              IS_REQUIRED: true
+              PROPERTY_NAME: os
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/os
+              TYPE_NAME: ""
+              maxLength: 25
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+            platform:
+              IS_REQUIRED: true
+              PROPERTY_NAME: platform
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/platform
+              TYPE_NAME: ""
+              maxLength: 100
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+          SortedPropertyNames:
+          - architecture
+          - name
+          - os
+          - platform
+          SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties
+        required:
+        - platform
+        - os
+        - architecture
+        type: object
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/buildMachine
+      TYPE_NAME: ""
+    buildSystem:
+      IS_REQUIRED: true
+      PROPERTY_NAME: buildSystem
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/buildSystem
+      TYPE_NAME: ""
+      description: |
+        The name of the build system that initiated this content.  Some examples
+        are "buildbot" and "taskcluster".  But this could be any name.  This
+        value will be used in the routing key for retriggering jobs in the
+        publish-job-action task.
+      maxLength: 25
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+    coalesced:
+      IS_REQUIRED: false
+      PROPERTY_NAME: coalesced
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/coalesced
+      TYPE_NAME: ""
+      description: The job guids that were coalesced to this job.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/coalesced/items
+        TYPE_NAME: ""
+        maxLength: 50
+        minLength: 1
+        pattern: ^[\w/+-]+$
+        title: Job GUID
+        type: string
+      title: Coalesced job GUID
+      type: array
+    display:
+      IS_REQUIRED: true
+      PROPERTY_NAME: display
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display
+      TYPE_NAME: Display
+      additionalProperties:
+        Boolean: false
+        Properties: null
+      properties:
+        MemberNames:
+          chunkCount: chunkCount
+          chunkId: chunkId
+          groupName: groupName
+          groupSymbol: groupSymbol
+          jobName: jobName
+          jobSymbol: jobSymbol
+        Properties:
+          chunkCount:
+            IS_REQUIRED: false
+            PROPERTY_NAME: chunkCount
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
+            TYPE_NAME: ""
+            minimum: 1
+            title: Chunk Count
+            type: integer
+          chunkId:
+            IS_REQUIRED: false
+            PROPERTY_NAME: chunkId
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
+            TYPE_NAME: ""
+            minimum: 1
+            title: Chunk ID
+            type: integer
+          groupName:
+            IS_REQUIRED: false
+            PROPERTY_NAME: groupName
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupName
+            TYPE_NAME: ""
+            maxLength: 100
+            minLength: 1
+            title: Group Name
+            type: string
+          groupSymbol:
+            IS_REQUIRED: true
+            PROPERTY_NAME: groupSymbol
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
+            TYPE_NAME: ""
+            maxLength: 25
+            minLength: 1
+            title: Group Symbol
+            type: string
+          jobName:
+            IS_REQUIRED: true
+            PROPERTY_NAME: jobName
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobName
+            TYPE_NAME: ""
+            maxLength: 100
+            minLength: 1
+            title: Job Name
+            type: string
+          jobSymbol:
+            IS_REQUIRED: true
+            PROPERTY_NAME: jobSymbol
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
+            TYPE_NAME: ""
+            maxLength: 25
+            minLength: 0
+            title: Job Symbol
+            type: string
+        SortedPropertyNames:
+        - chunkCount
+        - chunkId
+        - groupName
+        - groupSymbol
+        - jobName
+        - jobSymbol
+        SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties
+      required:
+      - jobName
+      - jobSymbol
+      - groupSymbol
+      type: object
+    extra:
+      IS_REQUIRED: false
+      PROPERTY_NAME: extra
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/extra
+      TYPE_NAME: ""
+      description: Extra information that Treeherder reads on a best-effort basis
+      type: object
+    isRetried:
+      IS_REQUIRED: false
+      PROPERTY_NAME: isRetried
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/isRetried
+      TYPE_NAME: ""
+      description: True indicates this job has been retried.
+      type: boolean
+    jobInfo:
+      IS_REQUIRED: false
+      PROPERTY_NAME: jobInfo
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo
+      TYPE_NAME: JobInfo
+      additionalProperties:
+        Boolean: false
+        Properties: null
+      description: |
+        Definition of the Job Info for a job.  These are extra data
+        fields that go along with a job that will be displayed in
+        the details panel within Treeherder.
+      properties:
+        MemberNames:
+          links: links
+          summary: summary
+        Properties:
+          links:
+            IS_REQUIRED: false
+            PROPERTY_NAME: links
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
+            TYPE_NAME: ""
+            items:
+              IS_REQUIRED: false
+              PROPERTY_NAME: ""
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+              TYPE_NAME: Link
+              additionalProperties:
+                Boolean: false
+                Properties: null
+              description: |
+                List of URLs shown as key/value pairs.  Shown as:
+                "<label>: <linkText>" where linkText will be a link to the url.
+              properties:
+                MemberNames:
+                  label: label
+                  linkText: linkText
+                  url: url
+                Properties:
+                  label:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: label
+                    SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+                    TYPE_NAME: ""
+                    maxLength: 70
+                    minLength: 1
+                    type: string
+                  linkText:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: linkText
+                    SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+                    TYPE_NAME: ""
+                    maxLength: 125
+                    minLength: 1
+                    type: string
+                  url:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: url
+                    SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+                    TYPE_NAME: ""
+                    format: uri
+                    maxLength: 512
+                    type: string
+                SortedPropertyNames:
+                - label
+                - linkText
+                - url
+                SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties
+              required:
+              - url
+              - linkText
+              - label
+              title: Link
+              type: object
+            type: array
+          summary:
+            IS_REQUIRED: false
+            PROPERTY_NAME: summary
+            SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
+            TYPE_NAME: ""
+            description: |
+              Plain text description of the job and its state.  Submitted with
+              the final message about a task.
+            type: string
+        SortedPropertyNames:
+        - links
+        - summary
+        SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties
+      type: object
+    jobKind:
+      IS_REQUIRED: true
+      PROPERTY_NAME: jobKind
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobKind
+      TYPE_NAME: ""
+      default: other
+      enum:
+      - build
+      - test
+      - other
+      type: string
+    labels:
+      IS_REQUIRED: false
+      PROPERTY_NAME: labels
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/labels
+      TYPE_NAME: ""
+      description: |
+        Labels are a dimension of a platform.  The values here can vary wildly,
+        so most strings are valid for this.  The list of labels that are used
+        is maleable going forward.
+
+        These were formerly known as "Options" within "Option Collections" but
+        calling labels now so they can be understood to be just strings that
+        denotes a characteristic of the job.
+
+        Some examples of labels that have been used:
+          opt    Optimize Compiler GCC optimize flags
+          debug  Debug flags passed in
+          pgo    Profile Guided Optimization - Like opt, but runs with profiling, then builds again using that profiling
+          asan   Address Sanitizer
+          tsan   Thread Sanitizer Build
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/labels/items
+        TYPE_NAME: ""
+        maxLength: 50
+        minLength: 1
+        pattern: ^[\w-]+$
+        title: Label
+        type: string
+      title: Labels
+      type: array
+    logs:
+      IS_REQUIRED: false
+      PROPERTY_NAME: logs
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs
+      TYPE_NAME: ""
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items
+        TYPE_NAME: Log
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        properties:
+          MemberNames:
+            errorsTruncated: errorsTruncated
+            name: name
+            steps: steps
+            url: url
+          Properties:
+            errorsTruncated:
+              IS_REQUIRED: false
+              PROPERTY_NAME: errorsTruncated
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
+              TYPE_NAME: ""
+              description: |
+                If true, indicates that the number of errors in the log was too
+                large and not all of those lines are indicated here.
+              type: boolean
+            name:
+              IS_REQUIRED: true
+              PROPERTY_NAME: name
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
+              TYPE_NAME: ""
+              maxLength: 50
+              minLength: 1
+              type: string
+            steps:
+              IS_REQUIRED: false
+              PROPERTY_NAME: steps
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
+              TYPE_NAME: ""
+              description: |
+                This object defines what is seen in the Treeherder Log Viewer.
+                These values can be submitted here, or they will be generated
+                by Treeherder's internal log parsing process from the
+                submitted log.  If this value is submitted, Treeherder will
+                consider the log already parsed and skip parsing.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: ""
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+                TYPE_NAME: Step
+                additionalProperties:
+                  Boolean: false
+                  Properties: null
+                properties:
+                  MemberNames:
+                    errors: errors
+                    lineFinished: lineFinished
+                    lineStarted: lineStarted
+                    name: name
+                    result: result
+                    timeFinished: timeFinished
+                    timeStarted: timeStarted
+                  Properties:
+                    errors:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: errors
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+                      TYPE_NAME: ""
+                      items:
+                        IS_REQUIRED: false
+                        PROPERTY_NAME: ""
+                        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+                        TYPE_NAME: Error
+                        additionalProperties:
+                          Boolean: false
+                          Properties: null
+                        properties:
+                          MemberNames:
+                            line: line
+                            linenumber: linenumber
+                          Properties:
+                            line:
+                              IS_REQUIRED: false
+                              PROPERTY_NAME: line
+                              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+                              TYPE_NAME: ""
+                              maxLength: 255
+                              minLength: 1
+                              type: string
+                            linenumber:
+                              IS_REQUIRED: false
+                              PROPERTY_NAME: linenumber
+                              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+                              TYPE_NAME: ""
+                              minimum: 0
+                              type: integer
+                          SortedPropertyNames:
+                          - line
+                          - linenumber
+                          SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties
+                        title: Error
+                        type: object
+                      type: array
+                    lineFinished:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: lineFinished
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+                      TYPE_NAME: ""
+                      minimum: 0
+                      type: integer
+                    lineStarted:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: lineStarted
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+                      TYPE_NAME: ""
+                      minimum: 0
+                      type: integer
+                    name:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: name
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+                      TYPE_NAME: ""
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    result:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: result
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+                      TYPE_NAME: ""
+                      enum:
+                      - success
+                      - fail
+                      - exception
+                      - canceled
+                      - unknown
+                      type: string
+                    timeFinished:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: timeFinished
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+                      TYPE_NAME: ""
+                      format: date-time
+                      type: string
+                    timeStarted:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: timeStarted
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+                      TYPE_NAME: ""
+                      format: date-time
+                      type: string
+                  SortedPropertyNames:
+                  - errors
+                  - lineFinished
+                  - lineStarted
+                  - name
+                  - result
+                  - timeFinished
+                  - timeStarted
+                  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties
+                required:
+                - name
+                - timeStarted
+                - lineStarted
+                - lineFinished
+                - timeFinished
+                - result
+                title: Step
+                type: object
+              type: array
+            url:
+              IS_REQUIRED: true
+              PROPERTY_NAME: url
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
+              TYPE_NAME: ""
+              format: uri
+              maxLength: 255
+              minLength: 1
+              type: string
+          SortedPropertyNames:
+          - errorsTruncated
+          - name
+          - steps
+          - url
+          SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties
+        required:
+        - url
+        - name
+        title: Log
+        type: object
+      type: array
+    origin:
+      IS_REQUIRED: true
+      PROPERTY_NAME: origin
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin
+      TYPE_NAME: ""
+      oneOf:
+        Items:
+        - IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]
+          TYPE_NAME: HGPush
+          additionalProperties:
+            Boolean: false
+            Properties: null
+          description: |
+            PREFERRED: An HG job that only has a revision.  This is for all
+            jobs going forward.
+          properties:
+            MemberNames:
+              kind: kind
+              project: project
+              pushLogID: pushLogID
+              revision: revision
+            Properties:
+              kind:
+                IS_REQUIRED: true
+                PROPERTY_NAME: kind
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/kind
+                TYPE_NAME: ""
+                enum:
+                - hg.mozilla.org
+                type: string
+              project:
+                IS_REQUIRED: true
+                PROPERTY_NAME: project
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/project
+                TYPE_NAME: ""
+                maxLength: 50
+                minLength: 1
+                pattern: ^[\w-]+$
+                type: string
+              pushLogID:
+                IS_REQUIRED: false
+                PROPERTY_NAME: pushLogID
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/pushLogID
+                TYPE_NAME: ""
+                type: integer
+              revision:
+                IS_REQUIRED: true
+                PROPERTY_NAME: revision
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/revision
+                TYPE_NAME: ""
+                maxLength: 40
+                minLength: 40
+                pattern: ^[0-9a-f]+$
+                type: string
+            SortedPropertyNames:
+            - kind
+            - project
+            - pushLogID
+            - revision
+            SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties
+          required:
+          - kind
+          - project
+          - revision
+          title: HG Push
+          type: object
+        - IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]
+          TYPE_NAME: GithubPullRequest
+          additionalProperties:
+            Boolean: false
+            Properties: null
+          properties:
+            MemberNames:
+              kind: kind
+              owner: owner
+              project: project
+              pullRequestID: pullRequestID
+              revision: revision
+            Properties:
+              kind:
+                IS_REQUIRED: true
+                PROPERTY_NAME: kind
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/kind
+                TYPE_NAME: ""
+                enum:
+                - github.com
+                type: string
+              owner:
+                IS_REQUIRED: false
+                PROPERTY_NAME: owner
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/owner
+                TYPE_NAME: ""
+                description: |
+                  This could be the organization or the individual git username
+                  depending on who owns the repo.
+                maxLength: 50
+                minLength: 1
+                pattern: ^[\w-]+$
+                type: string
+              project:
+                IS_REQUIRED: true
+                PROPERTY_NAME: project
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/project
+                TYPE_NAME: ""
+                maxLength: 50
+                minLength: 1
+                pattern: ^[\w-]+$
+                type: string
+              pullRequestID:
+                IS_REQUIRED: false
+                PROPERTY_NAME: pullRequestID
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/pullRequestID
+                TYPE_NAME: ""
+                type: integer
+              revision:
+                IS_REQUIRED: true
+                PROPERTY_NAME: revision
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/revision
+                TYPE_NAME: ""
+                maxLength: 40
+                minLength: 40
+                type: string
+            SortedPropertyNames:
+            - kind
+            - owner
+            - project
+            - pullRequestID
+            - revision
+            SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties
+          required:
+          - kind
+          - project
+          - revision
+          title: Github Pull Request
+          type: object
+        SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf
+      type: object
+    owner:
+      IS_REQUIRED: false
+      PROPERTY_NAME: owner
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/owner
+      TYPE_NAME: ""
+      description: |
+        Description of who submitted the job: gaia | scheduler name | username | email
+      maxLength: 50
+      minLength: 1
+      title: Owner
+      type: string
+    productName:
+      IS_REQUIRED: false
+      PROPERTY_NAME: productName
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/productName
+      TYPE_NAME: ""
+      description: |
+        Examples include:
+        -  'b2g'
+        -  'firefox'
+        -  'taskcluster'
+        -  'xulrunner'
+      maxLength: 125
+      minLength: 1
+      type: string
+    reason:
+      IS_REQUIRED: false
+      PROPERTY_NAME: reason
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/reason
+      TYPE_NAME: ""
+      description: |
+        Examples include:
+        - scheduled
+        - scheduler
+        - Self-serve: Rebuilt by foo@example.com
+        - Self-serve: Requested by foo@example.com
+        - The Nightly scheduler named 'b2g_mozilla-inbound periodic' triggered this build
+        - unknown
+      maxLength: 125
+      minLength: 1
+      type: string
+    result:
+      IS_REQUIRED: false
+      PROPERTY_NAME: result
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/result
+      TYPE_NAME: ""
+      description: |
+        fail: A failure
+        exception: An infrastructure error/exception
+        success: Build/Test executed without error or failure
+        canceled: The job was cancelled by a user
+        unknown: When the job is not yet completed
+        superseded: When a job has been superseded by another job
+      enum:
+      - success
+      - fail
+      - exception
+      - canceled
+      - superseded
+      - unknown
+      title: Result
+      type: string
+    retryId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: retryId
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/retryId
+      TYPE_NAME: ""
+      default: 0
+      description: |
+        The infrastructure retry iteration on this job.  The number of times this
+        job has been retried by the infrastructure.
+        If it's the 1st time running, then it should be 0. If this is the first
+        retry, it will be 1, etc.
+      minimum: 0
+      title: Retry ID
+      type: integer
+    runMachine:
+      $ref: '#/definitions/machine'
+      IS_REQUIRED: false
+      PROPERTY_NAME: runMachine
+      REF_SCHEMA_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
+      REF_SUBSCHEMA:
+        IS_REQUIRED: false
+        PROPERTY_NAME: machine
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
+        TYPE_NAME: Machine
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        properties:
+          MemberNames:
+            architecture: architecture
+            name: name
+            os: os
+            platform: platform
+          Properties:
+            architecture:
+              IS_REQUIRED: true
+              PROPERTY_NAME: architecture
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/architecture
+              TYPE_NAME: ""
+              maxLength: 25
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+            name:
+              IS_REQUIRED: false
+              PROPERTY_NAME: name
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/name
+              TYPE_NAME: ""
+              maxLength: 50
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+            os:
+              IS_REQUIRED: true
+              PROPERTY_NAME: os
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/os
+              TYPE_NAME: ""
+              maxLength: 25
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+            platform:
+              IS_REQUIRED: true
+              PROPERTY_NAME: platform
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/platform
+              TYPE_NAME: ""
+              maxLength: 100
+              minLength: 1
+              pattern: ^[\w-]+$
+              type: string
+          SortedPropertyNames:
+          - architecture
+          - name
+          - os
+          - platform
+          SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties
+        required:
+        - platform
+        - os
+        - architecture
+        type: object
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/runMachine
+      TYPE_NAME: ""
+    state:
+      IS_REQUIRED: true
+      PROPERTY_NAME: state
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/state
+      TYPE_NAME: ""
+      description: |
+        unscheduled: not yet scheduled
+        pending: not yet started
+        running: currently in progress
+        completed: Job ran through to completion
+      enum:
+      - unscheduled
+      - pending
+      - running
+      - completed
+      title: State
+      type: string
+    taskId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: taskId
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/taskId
+      TYPE_NAME: ""
+      description: |
+        This could just be what was formerly submitted as a job_guid in the
+        REST API.
+      maxLength: 50
+      minLength: 1
+      pattern: ^[A-Za-z0-9/+-]+$
+      title: Task ID
+      type: string
+    tier:
+      IS_REQUIRED: false
+      PROPERTY_NAME: tier
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/tier
+      TYPE_NAME: ""
+      maximum: 3
+      minimum: 1
+      type: integer
+    timeCompleted:
+      IS_REQUIRED: false
+      PROPERTY_NAME: timeCompleted
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/timeCompleted
+      TYPE_NAME: ""
+      format: date-time
+      type: string
+    timeScheduled:
+      IS_REQUIRED: false
+      PROPERTY_NAME: timeScheduled
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/timeScheduled
+      TYPE_NAME: ""
+      format: date-time
+      type: string
+    timeStarted:
+      IS_REQUIRED: false
+      PROPERTY_NAME: timeStarted
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/timeStarted
+      TYPE_NAME: ""
+      format: date-time
+      type: string
+    version:
+      IS_REQUIRED: true
+      PROPERTY_NAME: version
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/version
+      TYPE_NAME: ""
+      description: Message version
+      enum:
+      - 1
+      type: integer
+  SortedPropertyNames:
+  - buildMachine
+  - buildSystem
+  - coalesced
+  - display
+  - extra
+  - isRetried
+  - jobInfo
+  - jobKind
+  - labels
+  - logs
+  - origin
+  - owner
+  - productName
+  - reason
+  - result
+  - retryId
+  - runMachine
+  - state
+  - taskId
+  - tier
+  - timeCompleted
+  - timeScheduled
+  - timeStarted
+  - version
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties
+required:
+- taskId
+- origin
+- buildSystem
+- display
+- state
+- jobKind
+- version
+title: Job Definition
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
+=================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: machine
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
+TYPE_NAME: Machine
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    architecture: architecture
+    name: name
+    os: os
+    platform: platform
+  Properties:
+    architecture:
+      IS_REQUIRED: true
+      PROPERTY_NAME: architecture
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/architecture
+      TYPE_NAME: ""
+      maxLength: 25
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+    name:
+      IS_REQUIRED: false
+      PROPERTY_NAME: name
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/name
+      TYPE_NAME: ""
+      maxLength: 50
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+    os:
+      IS_REQUIRED: true
+      PROPERTY_NAME: os
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/os
+      TYPE_NAME: ""
+      maxLength: 25
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+    platform:
+      IS_REQUIRED: true
+      PROPERTY_NAME: platform
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/platform
+      TYPE_NAME: ""
+      maxLength: 100
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+  SortedPropertyNames:
+  - architecture
+  - name
+  - os
+  - platform
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties
+required:
+- platform
+- os
+- architecture
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display
+================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: display
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display
+TYPE_NAME: Display
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    chunkCount: chunkCount
+    chunkId: chunkId
+    groupName: groupName
+    groupSymbol: groupSymbol
+    jobName: jobName
+    jobSymbol: jobSymbol
+  Properties:
+    chunkCount:
+      IS_REQUIRED: false
+      PROPERTY_NAME: chunkCount
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
+      TYPE_NAME: ""
+      minimum: 1
+      title: Chunk Count
+      type: integer
+    chunkId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: chunkId
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
+      TYPE_NAME: ""
+      minimum: 1
+      title: Chunk ID
+      type: integer
+    groupName:
+      IS_REQUIRED: false
+      PROPERTY_NAME: groupName
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupName
+      TYPE_NAME: ""
+      maxLength: 100
+      minLength: 1
+      title: Group Name
+      type: string
+    groupSymbol:
+      IS_REQUIRED: true
+      PROPERTY_NAME: groupSymbol
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
+      TYPE_NAME: ""
+      maxLength: 25
+      minLength: 1
+      title: Group Symbol
+      type: string
+    jobName:
+      IS_REQUIRED: true
+      PROPERTY_NAME: jobName
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobName
+      TYPE_NAME: ""
+      maxLength: 100
+      minLength: 1
+      title: Job Name
+      type: string
+    jobSymbol:
+      IS_REQUIRED: true
+      PROPERTY_NAME: jobSymbol
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
+      TYPE_NAME: ""
+      maxLength: 25
+      minLength: 0
+      title: Job Symbol
+      type: string
+  SortedPropertyNames:
+  - chunkCount
+  - chunkId
+  - groupName
+  - groupSymbol
+  - jobName
+  - jobSymbol
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties
+required:
+- jobName
+- jobSymbol
+- groupSymbol
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo
+================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: jobInfo
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo
+TYPE_NAME: JobInfo
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Definition of the Job Info for a job.  These are extra data
+  fields that go along with a job that will be displayed in
+  the details panel within Treeherder.
+properties:
+  MemberNames:
+    links: links
+    summary: summary
+  Properties:
+    links:
+      IS_REQUIRED: false
+      PROPERTY_NAME: links
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
+      TYPE_NAME: ""
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+        TYPE_NAME: Link
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          List of URLs shown as key/value pairs.  Shown as:
+          "<label>: <linkText>" where linkText will be a link to the url.
+        properties:
+          MemberNames:
+            label: label
+            linkText: linkText
+            url: url
+          Properties:
+            label:
+              IS_REQUIRED: true
+              PROPERTY_NAME: label
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+              TYPE_NAME: ""
+              maxLength: 70
+              minLength: 1
+              type: string
+            linkText:
+              IS_REQUIRED: true
+              PROPERTY_NAME: linkText
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+              TYPE_NAME: ""
+              maxLength: 125
+              minLength: 1
+              type: string
+            url:
+              IS_REQUIRED: true
+              PROPERTY_NAME: url
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+              TYPE_NAME: ""
+              format: uri
+              maxLength: 512
+              type: string
+          SortedPropertyNames:
+          - label
+          - linkText
+          - url
+          SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties
+        required:
+        - url
+        - linkText
+        - label
+        title: Link
+        type: object
+      type: array
+    summary:
+      IS_REQUIRED: false
+      PROPERTY_NAME: summary
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
+      TYPE_NAME: ""
+      description: |
+        Plain text description of the job and its state.  Submitted with
+        the final message about a task.
+      type: string
+  SortedPropertyNames:
+  - links
+  - summary
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+=======================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+TYPE_NAME: Link
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  List of URLs shown as key/value pairs.  Shown as:
+  "<label>: <linkText>" where linkText will be a link to the url.
+properties:
+  MemberNames:
+    label: label
+    linkText: linkText
+    url: url
+  Properties:
+    label:
+      IS_REQUIRED: true
+      PROPERTY_NAME: label
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+      TYPE_NAME: ""
+      maxLength: 70
+      minLength: 1
+      type: string
+    linkText:
+      IS_REQUIRED: true
+      PROPERTY_NAME: linkText
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+      TYPE_NAME: ""
+      maxLength: 125
+      minLength: 1
+      type: string
+    url:
+      IS_REQUIRED: true
+      PROPERTY_NAME: url
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+      TYPE_NAME: ""
+      format: uri
+      maxLength: 512
+      type: string
+  SortedPropertyNames:
+  - label
+  - linkText
+  - url
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties
+required:
+- url
+- linkText
+- label
+title: Link
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items
+===================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items
+TYPE_NAME: Log
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    errorsTruncated: errorsTruncated
+    name: name
+    steps: steps
+    url: url
+  Properties:
+    errorsTruncated:
+      IS_REQUIRED: false
+      PROPERTY_NAME: errorsTruncated
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
+      TYPE_NAME: ""
+      description: |
+        If true, indicates that the number of errors in the log was too
+        large and not all of those lines are indicated here.
+      type: boolean
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
+      TYPE_NAME: ""
+      maxLength: 50
+      minLength: 1
+      type: string
+    steps:
+      IS_REQUIRED: false
+      PROPERTY_NAME: steps
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
+      TYPE_NAME: ""
+      description: |
+        This object defines what is seen in the Treeherder Log Viewer.
+        These values can be submitted here, or they will be generated
+        by Treeherder's internal log parsing process from the
+        submitted log.  If this value is submitted, Treeherder will
+        consider the log already parsed and skip parsing.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+        TYPE_NAME: Step
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        properties:
+          MemberNames:
+            errors: errors
+            lineFinished: lineFinished
+            lineStarted: lineStarted
+            name: name
+            result: result
+            timeFinished: timeFinished
+            timeStarted: timeStarted
+          Properties:
+            errors:
+              IS_REQUIRED: false
+              PROPERTY_NAME: errors
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+              TYPE_NAME: ""
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: ""
+                SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+                TYPE_NAME: Error
+                additionalProperties:
+                  Boolean: false
+                  Properties: null
+                properties:
+                  MemberNames:
+                    line: line
+                    linenumber: linenumber
+                  Properties:
+                    line:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: line
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+                      TYPE_NAME: ""
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    linenumber:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: linenumber
+                      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+                      TYPE_NAME: ""
+                      minimum: 0
+                      type: integer
+                  SortedPropertyNames:
+                  - line
+                  - linenumber
+                  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties
+                title: Error
+                type: object
+              type: array
+            lineFinished:
+              IS_REQUIRED: true
+              PROPERTY_NAME: lineFinished
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+              TYPE_NAME: ""
+              minimum: 0
+              type: integer
+            lineStarted:
+              IS_REQUIRED: true
+              PROPERTY_NAME: lineStarted
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+              TYPE_NAME: ""
+              minimum: 0
+              type: integer
+            name:
+              IS_REQUIRED: true
+              PROPERTY_NAME: name
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+              TYPE_NAME: ""
+              maxLength: 255
+              minLength: 1
+              type: string
+            result:
+              IS_REQUIRED: true
+              PROPERTY_NAME: result
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+              TYPE_NAME: ""
+              enum:
+              - success
+              - fail
+              - exception
+              - canceled
+              - unknown
+              type: string
+            timeFinished:
+              IS_REQUIRED: true
+              PROPERTY_NAME: timeFinished
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+              TYPE_NAME: ""
+              format: date-time
+              type: string
+            timeStarted:
+              IS_REQUIRED: true
+              PROPERTY_NAME: timeStarted
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+              TYPE_NAME: ""
+              format: date-time
+              type: string
+          SortedPropertyNames:
+          - errors
+          - lineFinished
+          - lineStarted
+          - name
+          - result
+          - timeFinished
+          - timeStarted
+          SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties
+        required:
+        - name
+        - timeStarted
+        - lineStarted
+        - lineFinished
+        - timeFinished
+        - result
+        title: Step
+        type: object
+      type: array
+    url:
+      IS_REQUIRED: true
+      PROPERTY_NAME: url
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
+      TYPE_NAME: ""
+      format: uri
+      maxLength: 255
+      minLength: 1
+      type: string
+  SortedPropertyNames:
+  - errorsTruncated
+  - name
+  - steps
+  - url
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties
+required:
+- url
+- name
+title: Log
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+==========================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+TYPE_NAME: Step
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    errors: errors
+    lineFinished: lineFinished
+    lineStarted: lineStarted
+    name: name
+    result: result
+    timeFinished: timeFinished
+    timeStarted: timeStarted
+  Properties:
+    errors:
+      IS_REQUIRED: false
+      PROPERTY_NAME: errors
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+      TYPE_NAME: ""
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+        TYPE_NAME: Error
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        properties:
+          MemberNames:
+            line: line
+            linenumber: linenumber
+          Properties:
+            line:
+              IS_REQUIRED: false
+              PROPERTY_NAME: line
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+              TYPE_NAME: ""
+              maxLength: 255
+              minLength: 1
+              type: string
+            linenumber:
+              IS_REQUIRED: false
+              PROPERTY_NAME: linenumber
+              SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+              TYPE_NAME: ""
+              minimum: 0
+              type: integer
+          SortedPropertyNames:
+          - line
+          - linenumber
+          SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties
+        title: Error
+        type: object
+      type: array
+    lineFinished:
+      IS_REQUIRED: true
+      PROPERTY_NAME: lineFinished
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+      TYPE_NAME: ""
+      minimum: 0
+      type: integer
+    lineStarted:
+      IS_REQUIRED: true
+      PROPERTY_NAME: lineStarted
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+      TYPE_NAME: ""
+      minimum: 0
+      type: integer
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+      TYPE_NAME: ""
+      maxLength: 255
+      minLength: 1
+      type: string
+    result:
+      IS_REQUIRED: true
+      PROPERTY_NAME: result
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+      TYPE_NAME: ""
+      enum:
+      - success
+      - fail
+      - exception
+      - canceled
+      - unknown
+      type: string
+    timeFinished:
+      IS_REQUIRED: true
+      PROPERTY_NAME: timeFinished
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+      TYPE_NAME: ""
+      format: date-time
+      type: string
+    timeStarted:
+      IS_REQUIRED: true
+      PROPERTY_NAME: timeStarted
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+      TYPE_NAME: ""
+      format: date-time
+      type: string
+  SortedPropertyNames:
+  - errors
+  - lineFinished
+  - lineStarted
+  - name
+  - result
+  - timeFinished
+  - timeStarted
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties
+required:
+- name
+- timeStarted
+- lineStarted
+- lineFinished
+- timeFinished
+- result
+title: Step
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+==================================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+TYPE_NAME: Error
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    line: line
+    linenumber: linenumber
+  Properties:
+    line:
+      IS_REQUIRED: false
+      PROPERTY_NAME: line
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+      TYPE_NAME: ""
+      maxLength: 255
+      minLength: 1
+      type: string
+    linenumber:
+      IS_REQUIRED: false
+      PROPERTY_NAME: linenumber
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+      TYPE_NAME: ""
+      minimum: 0
+      type: integer
+  SortedPropertyNames:
+  - line
+  - linenumber
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties
+title: Error
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]
+========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]
+TYPE_NAME: HGPush
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  PREFERRED: An HG job that only has a revision.  This is for all
+  jobs going forward.
+properties:
+  MemberNames:
+    kind: kind
+    project: project
+    pushLogID: pushLogID
+    revision: revision
+  Properties:
+    kind:
+      IS_REQUIRED: true
+      PROPERTY_NAME: kind
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/kind
+      TYPE_NAME: ""
+      enum:
+      - hg.mozilla.org
+      type: string
+    project:
+      IS_REQUIRED: true
+      PROPERTY_NAME: project
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/project
+      TYPE_NAME: ""
+      maxLength: 50
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+    pushLogID:
+      IS_REQUIRED: false
+      PROPERTY_NAME: pushLogID
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/pushLogID
+      TYPE_NAME: ""
+      type: integer
+    revision:
+      IS_REQUIRED: true
+      PROPERTY_NAME: revision
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/revision
+      TYPE_NAME: ""
+      maxLength: 40
+      minLength: 40
+      pattern: ^[0-9a-f]+$
+      type: string
+  SortedPropertyNames:
+  - kind
+  - project
+  - pushLogID
+  - revision
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties
+required:
+- kind
+- project
+- revision
+title: HG Push
+type: object
+
+
+https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]
+========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]
+TYPE_NAME: GithubPullRequest
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    kind: kind
+    owner: owner
+    project: project
+    pullRequestID: pullRequestID
+    revision: revision
+  Properties:
+    kind:
+      IS_REQUIRED: true
+      PROPERTY_NAME: kind
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/kind
+      TYPE_NAME: ""
+      enum:
+      - github.com
+      type: string
+    owner:
+      IS_REQUIRED: false
+      PROPERTY_NAME: owner
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/owner
+      TYPE_NAME: ""
+      description: |
+        This could be the organization or the individual git username
+        depending on who owns the repo.
+      maxLength: 50
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+    project:
+      IS_REQUIRED: true
+      PROPERTY_NAME: project
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/project
+      TYPE_NAME: ""
+      maxLength: 50
+      minLength: 1
+      pattern: ^[\w-]+$
+      type: string
+    pullRequestID:
+      IS_REQUIRED: false
+      PROPERTY_NAME: pullRequestID
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/pullRequestID
+      TYPE_NAME: ""
+      type: integer
+    revision:
+      IS_REQUIRED: true
+      PROPERTY_NAME: revision
+      SOURCE_URL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/revision
+      TYPE_NAME: ""
+      maxLength: 40
+      minLength: 40
+      type: string
+  SortedPropertyNames:
+  - kind
+  - owner
+  - project
+  - pullRequestID
+  - revision
+  SourceURL: https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties
+required:
+- kind
+- project
+- revision
+title: Github Pull Request
+type: object
+
+

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Display.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Display.java
@@ -1,7 +1,7 @@
 package org.mozilla.taskcluster.client.treeherderevents;
 
 /**
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display
  */
 public class Display {
 
@@ -9,7 +9,7 @@ public class Display {
      *
      * Mininum:    1
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
      */
     public int chunkCount;
 
@@ -17,7 +17,7 @@ public class Display {
      *
      * Mininum:    1
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
      */
     public int chunkId;
 
@@ -26,7 +26,7 @@ public class Display {
      * Min length: 1
      * Max length: 100
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupName
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupName
      */
     public String groupName;
 
@@ -35,7 +35,7 @@ public class Display {
      * Min length: 1
      * Max length: 25
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
      */
     public String groupSymbol;
 
@@ -44,7 +44,7 @@ public class Display {
      * Min length: 1
      * Max length: 100
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobName
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobName
      */
     public String jobName;
 
@@ -53,7 +53,7 @@ public class Display {
      * Min length: 0
      * Max length: 25
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
      */
     public String jobSymbol;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Error.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Error.java
@@ -1,7 +1,7 @@
 package org.mozilla.taskcluster.client.treeherderevents;
 
 /**
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
  */
 public class Error {
 
@@ -10,7 +10,7 @@ public class Error {
      * Min length: 1
      * Max length: 255
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
      */
     public String line;
 
@@ -18,7 +18,7 @@ public class Error {
      *
      * Mininum:    0
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
      */
     public int linenumber;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/GithubPullRequest.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/GithubPullRequest.java
@@ -1,7 +1,7 @@
 package org.mozilla.taskcluster.client.treeherderevents;
 
 /**
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]
  */
 public class GithubPullRequest {
 
@@ -10,7 +10,7 @@ public class GithubPullRequest {
      * Possible values:
      *     * "github.com"
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/kind
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/kind
      */
     public String kind;
 
@@ -22,7 +22,7 @@ public class GithubPullRequest {
      * Min length: 1
      * Max length: 50
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/owner
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/owner
      */
     public String owner;
 
@@ -32,12 +32,12 @@ public class GithubPullRequest {
      * Min length: 1
      * Max length: 50
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/project
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/project
      */
     public String project;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/pullRequestID
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/pullRequestID
      */
     public int pullRequestID;
 
@@ -46,7 +46,7 @@ public class GithubPullRequest {
      * Min length: 40
      * Max length: 40
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/revision
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[1]/properties/revision
      */
     public String revision;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/HGPush.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/HGPush.java
@@ -4,7 +4,7 @@ package org.mozilla.taskcluster.client.treeherderevents;
  * PREFERRED: An HG job that only has a revision.  This is for all
  * jobs going forward.
  *
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]
  */
 public class HGPush {
 
@@ -13,7 +13,7 @@ public class HGPush {
      * Possible values:
      *     * "hg.mozilla.org"
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/kind
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/kind
      */
     public String kind;
 
@@ -23,12 +23,12 @@ public class HGPush {
      * Min length: 1
      * Max length: 50
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/project
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/project
      */
     public String project;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/pushLogID
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/pushLogID
      */
     public int pushLogID;
 
@@ -38,7 +38,7 @@ public class HGPush {
      * Min length: 40
      * Max length: 40
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/revision
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]/properties/revision
      */
     public String revision;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/JobDefinition.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/JobDefinition.java
@@ -6,12 +6,12 @@ import java.util.Date;
  * Definition of a single job that can be added to Treeherder
  * Project is determined by the routing key, so we don't need to specify it here.
  *
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#
  */
 public class JobDefinition {
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/buildMachine
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/buildMachine
      */
     public Machine buildMachine;
 
@@ -25,14 +25,14 @@ public class JobDefinition {
      * Min length: 1
      * Max length: 25
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/buildSystem
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/buildSystem
      */
     public String buildSystem;
 
     /**
      * The job guids that were coalesced to this job.
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/coalesced
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/coalesced
      */
     public String[] coalesced;
 
@@ -42,7 +42,7 @@ public class JobDefinition {
          *
          * Mininum:    1
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
          */
         public int chunkCount;
 
@@ -50,7 +50,7 @@ public class JobDefinition {
          *
          * Mininum:    1
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
          */
         public int chunkId;
 
@@ -59,7 +59,7 @@ public class JobDefinition {
          * Min length: 1
          * Max length: 100
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupName
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupName
          */
         public String groupName;
 
@@ -68,7 +68,7 @@ public class JobDefinition {
          * Min length: 1
          * Max length: 25
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
          */
         public String groupSymbol;
 
@@ -77,7 +77,7 @@ public class JobDefinition {
          * Min length: 1
          * Max length: 100
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobName
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobName
          */
         public String jobName;
 
@@ -86,27 +86,27 @@ public class JobDefinition {
          * Min length: 0
          * Max length: 25
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
          */
         public String jobSymbol;
     }
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/display
      */
     public Display display;
 
     /**
      * Extra information that Treeherder reads on a best-effort basis
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/extra
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/extra
      */
     public Object extra;
 
     /**
      * True indicates this job has been retried.
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/isRetried
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/isRetried
      */
     public boolean isRetried;
 
@@ -119,7 +119,7 @@ public class JobDefinition {
              * Min length: 1
              * Max length: 70
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
              */
             public String label;
 
@@ -128,7 +128,7 @@ public class JobDefinition {
              * Min length: 1
              * Max length: 125
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
              */
             public String linkText;
 
@@ -136,13 +136,13 @@ public class JobDefinition {
              *
              * Max length: 512
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
              */
             public String url;
         }
 
         /**
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
          */
         public Link[] links;
 
@@ -150,7 +150,7 @@ public class JobDefinition {
          * Plain text description of the job and its state.  Submitted with
          * the final message about a task.
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
          */
         public String summary;
     }
@@ -160,7 +160,7 @@ public class JobDefinition {
      * fields that go along with a job that will be displayed in
      * the details panel within Treeherder.
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo
      */
     public JobInfo jobInfo;
 
@@ -172,7 +172,7 @@ public class JobDefinition {
      *     * "other"
      * Default:    "other"
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobKind
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobKind
      */
     public String jobKind;
 
@@ -192,7 +192,7 @@ public class JobDefinition {
      *   asan   Address Sanitizer
      *   tsan   Thread Sanitizer Build
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/labels
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/labels
      */
     public String[] labels;
 
@@ -202,7 +202,7 @@ public class JobDefinition {
          * If true, indicates that the number of errors in the log was too
          * large and not all of those lines are indicated here.
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
          */
         public boolean errorsTruncated;
 
@@ -211,7 +211,7 @@ public class JobDefinition {
          * Min length: 1
          * Max length: 50
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
          */
         public String name;
 
@@ -224,7 +224,7 @@ public class JobDefinition {
                  * Min length: 1
                  * Max length: 255
                  *
-                 * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+                 * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
                  */
                 public String line;
 
@@ -232,13 +232,13 @@ public class JobDefinition {
                  *
                  * Mininum:    0
                  *
-                 * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+                 * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
                  */
                 public int linenumber;
             }
 
             /**
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
              */
             public Error[] errors;
 
@@ -246,7 +246,7 @@ public class JobDefinition {
              *
              * Mininum:    0
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
              */
             public int lineFinished;
 
@@ -254,7 +254,7 @@ public class JobDefinition {
              *
              * Mininum:    0
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
              */
             public int lineStarted;
 
@@ -263,7 +263,7 @@ public class JobDefinition {
              * Min length: 1
              * Max length: 255
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
              */
             public String name;
 
@@ -276,17 +276,17 @@ public class JobDefinition {
              *     * "canceled"
              *     * "unknown"
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
              */
             public String result;
 
             /**
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
              */
             public Date timeFinished;
 
             /**
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
              */
             public Date timeStarted;
         }
@@ -298,7 +298,7 @@ public class JobDefinition {
          * submitted log.  If this value is submitted, Treeherder will
          * consider the log already parsed and skip parsing.
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
          */
         public Step[] steps;
 
@@ -307,18 +307,18 @@ public class JobDefinition {
          * Min length: 1
          * Max length: 255
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
          */
         public String url;
     }
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs
      */
     public Log[] logs;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/origin
      */
     public Object origin;
 
@@ -328,7 +328,7 @@ public class JobDefinition {
      * Min length: 1
      * Max length: 50
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/owner
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/owner
      */
     public String owner;
 
@@ -342,7 +342,7 @@ public class JobDefinition {
      * Min length: 1
      * Max length: 125
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/productName
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/productName
      */
     public String productName;
 
@@ -358,7 +358,7 @@ public class JobDefinition {
      * Min length: 1
      * Max length: 125
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/reason
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/reason
      */
     public String reason;
 
@@ -378,7 +378,7 @@ public class JobDefinition {
      *     * "superseded"
      *     * "unknown"
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/result
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/result
      */
     public String result;
 
@@ -391,12 +391,12 @@ public class JobDefinition {
      * Default:    0
      * Mininum:    0
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/retryId
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/retryId
      */
     public int retryId;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/runMachine
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/runMachine
      */
     public Machine runMachine;
 
@@ -412,7 +412,7 @@ public class JobDefinition {
      *     * "running"
      *     * "completed"
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/state
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/state
      */
     public String state;
 
@@ -424,7 +424,7 @@ public class JobDefinition {
      * Min length: 1
      * Max length: 50
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/taskId
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/taskId
      */
     public String taskId;
 
@@ -433,22 +433,22 @@ public class JobDefinition {
      * Mininum:    1
      * Maximum:    3
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/tier
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/tier
      */
     public int tier;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/timeCompleted
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/timeCompleted
      */
     public Date timeCompleted;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/timeScheduled
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/timeScheduled
      */
     public Date timeScheduled;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/timeStarted
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/timeStarted
      */
     public Date timeStarted;
 
@@ -458,7 +458,7 @@ public class JobDefinition {
      * Possible values:
      *     * 1
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/version
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/version
      */
     public int version;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/JobInfo.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/JobInfo.java
@@ -5,7 +5,7 @@ package org.mozilla.taskcluster.client.treeherderevents;
  * fields that go along with a job that will be displayed in
  * the details panel within Treeherder.
  *
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo
  */
 public class JobInfo {
 
@@ -16,7 +16,7 @@ public class JobInfo {
          * Min length: 1
          * Max length: 70
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
          */
         public String label;
 
@@ -25,7 +25,7 @@ public class JobInfo {
          * Min length: 1
          * Max length: 125
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
          */
         public String linkText;
 
@@ -33,13 +33,13 @@ public class JobInfo {
          *
          * Max length: 512
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
          */
         public String url;
     }
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
      */
     public Link[] links;
 
@@ -47,7 +47,7 @@ public class JobInfo {
      * Plain text description of the job and its state.  Submitted with
      * the final message about a task.
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
      */
     public String summary;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Link.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Link.java
@@ -4,7 +4,7 @@ package org.mozilla.taskcluster.client.treeherderevents;
  * List of URLs shown as key/value pairs.  Shown as:
  * "<label>: <linkText>" where linkText will be a link to the url.
  *
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
  */
 public class Link {
 
@@ -13,7 +13,7 @@ public class Link {
      * Min length: 1
      * Max length: 70
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
      */
     public String label;
 
@@ -22,7 +22,7 @@ public class Link {
      * Min length: 1
      * Max length: 125
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
      */
     public String linkText;
 
@@ -30,7 +30,7 @@ public class Link {
      *
      * Max length: 512
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
      */
     public String url;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Log.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Log.java
@@ -3,7 +3,7 @@ package org.mozilla.taskcluster.client.treeherderevents;
 import java.util.Date;
 
 /**
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items
  */
 public class Log {
 
@@ -11,7 +11,7 @@ public class Log {
      * If true, indicates that the number of errors in the log was too
      * large and not all of those lines are indicated here.
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
      */
     public boolean errorsTruncated;
 
@@ -20,7 +20,7 @@ public class Log {
      * Min length: 1
      * Max length: 50
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
      */
     public String name;
 
@@ -33,7 +33,7 @@ public class Log {
              * Min length: 1
              * Max length: 255
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
              */
             public String line;
 
@@ -41,13 +41,13 @@ public class Log {
              *
              * Mininum:    0
              *
-             * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+             * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
              */
             public int linenumber;
         }
 
         /**
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
          */
         public Error[] errors;
 
@@ -55,7 +55,7 @@ public class Log {
          *
          * Mininum:    0
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
          */
         public int lineFinished;
 
@@ -63,7 +63,7 @@ public class Log {
          *
          * Mininum:    0
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
          */
         public int lineStarted;
 
@@ -72,7 +72,7 @@ public class Log {
          * Min length: 1
          * Max length: 255
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
          */
         public String name;
 
@@ -85,17 +85,17 @@ public class Log {
          *     * "canceled"
          *     * "unknown"
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
          */
         public String result;
 
         /**
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
          */
         public Date timeFinished;
 
         /**
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
          */
         public Date timeStarted;
     }
@@ -107,7 +107,7 @@ public class Log {
      * submitted log.  If this value is submitted, Treeherder will
      * consider the log already parsed and skip parsing.
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
      */
     public Step[] steps;
 
@@ -116,7 +116,7 @@ public class Log {
      * Min length: 1
      * Max length: 255
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
      */
     public String url;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Machine.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Machine.java
@@ -1,7 +1,7 @@
 package org.mozilla.taskcluster.client.treeherderevents;
 
 /**
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/definitions/machine
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine
  */
 public class Machine {
 
@@ -11,7 +11,7 @@ public class Machine {
      * Min length: 1
      * Max length: 25
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/definitions/machine/properties/architecture
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/architecture
      */
     public String architecture;
 
@@ -21,7 +21,7 @@ public class Machine {
      * Min length: 1
      * Max length: 50
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/definitions/machine/properties/name
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/name
      */
     public String name;
 
@@ -31,7 +31,7 @@ public class Machine {
      * Min length: 1
      * Max length: 25
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/definitions/machine/properties/os
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/os
      */
     public String os;
 
@@ -41,7 +41,7 @@ public class Machine {
      * Min length: 1
      * Max length: 100
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/definitions/machine/properties/platform
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/definitions/machine/properties/platform
      */
     public String platform;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Step.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/Step.java
@@ -3,7 +3,7 @@ package org.mozilla.taskcluster.client.treeherderevents;
 import java.util.Date;
 
 /**
- * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+ * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
  */
 public class Step {
 
@@ -14,7 +14,7 @@ public class Step {
          * Min length: 1
          * Max length: 255
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
          */
         public String line;
 
@@ -22,13 +22,13 @@ public class Step {
          *
          * Mininum:    0
          *
-         * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+         * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
          */
         public int linenumber;
     }
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
      */
     public Error[] errors;
 
@@ -36,7 +36,7 @@ public class Step {
      *
      * Mininum:    0
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
      */
     public int lineFinished;
 
@@ -44,7 +44,7 @@ public class Step {
      *
      * Mininum:    0
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
      */
     public int lineStarted;
 
@@ -53,7 +53,7 @@ public class Step {
      * Min length: 1
      * Max length: 255
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
      */
     public String name;
 
@@ -66,17 +66,17 @@ public class Step {
      *     * "canceled"
      *     * "unknown"
      *
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
      */
     public String result;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
      */
     public Date timeFinished;
 
     /**
-     * See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+     * See https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
      */
     public Date timeStarted;
 }

--- a/src/main/java/org/mozilla/taskcluster/client/treeherderevents/TreeherderEvents.java
+++ b/src/main/java/org/mozilla/taskcluster/client/treeherderevents/TreeherderEvents.java
@@ -1,4 +1,4 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
 //
 // This package was generated from the schema defined at
-// https://references.taskcluster.net/taskcluster-treeherder/v1/exchanges.json
+// https://references.taskcluster.net/treeherder/v1/exchanges.json


### PR DESCRIPTION
This reenables code generation for treeherder events in [bug 1428422](https://bugzil.la/1428422) since [bug 1462769](https://bugzil.la/1462769) landed.

Two commits; the first the changes, the second the generated code.